### PR TITLE
Fix error "LaTeX Error: Missing \begin{document}."

### DIFF
--- a/meta.cls
+++ b/meta.cls
@@ -154,7 +154,10 @@
 
 % code listings
 \RequirePackage{listings}
-  
+
+% etoolbox (for \AfterEndPreamble}
+\RequirePackage{etoolbox}
+
 % --------------
 % Main Code
 % --------------
@@ -453,8 +456,10 @@
 		pdfauthor = {\@author}
 	}
 	\makeatother
+}
+\AfterEndPreamble{
 	\maketitle
-	\clearpage	
+	\clearpage
 }
 
 


### PR DESCRIPTION
The `meta' class tries to \maketitle in the \AtBeginDocument hook, which is the
wrong place. Fix this by moving \maketitle to \AfterEndPreamble (etoolbox).

Additional info about this sort of error can be found in this comment by Heiko
Oberdiek: http://tex.stackexchange.com/a/235881

Fixes issue #2.