### PR TITLE
Downgrade "Changed paragraphs, rerun to get it right" error to warning

### DIFF
--- a/accessibilityMeta.sty
+++ b/accessibilityMeta.sty
@@ -761,9 +761,7 @@
   \def\testNextNumberedPage#1{%
    \ifx#1\relax%
      \global\def\NumberedPageCache{\gotNumberedPage0000}%
-     %\PackageWarning{accessibility}{Changed paragraphs, rerun to get it right}%
-     \PackageError{accessibility}{Changed paragraphs, rerun to get it right}%
-                                 {Changed paragraphs, rerun to get it right}%
+     \PackageWarning{accessibility}{Changed paragraphs, rerun to get it right}%
    \else%
      \global\let\NumberedPageCache#1%
    \fi%


### PR DESCRIPTION
accessibilityMeta.sty issues an error when paragraphs change. Downgrade this
to a warning to not stop the pdflatex run.