### PR TITLE
Remove indentation/space attributes from non-paragraphlike StructElems

### DIFF
--- a/accessibilityMeta.sty
+++ b/accessibilityMeta.sty
@@ -188,7 +188,6 @@
     \immediate \pdfobj useobjnum\number\Objnum{<</Type /StructElem %
         /P \ParentElem\space 0 R %
         \TitleHelp %
-        /C /Normal %
         \space\LanguageCode %
         /K [\csname \KidsArray\endcsname] %
         /S /\StructElem>>}%
@@ -311,7 +310,6 @@
   \fi%
   \immediate \pdfobj useobjnum\theTextObjNum{<</Type /StructElem %
      /P \ParentElem \space 0 R %
-     /C /Normal %
      /K [\TextArray] %
      /S /\TextType %
     \space\LanguageCode %
@@ -425,7 +423,6 @@
   }%
   \immediate \pdfobj {<</Type /StructElem %
     /P \theTextObjNum \space 0 R %
-    /C /Normal %
     /K <</Type /MCR %
     	% this fix allows roman numerals to be used
          % /Pg \pdfpageref\thepage \space \space 0 R %
@@ -449,13 +446,11 @@
       /P #4\space 0 R %
       % /Pg \pdfpageref\thepage \space \space 0 R %
       /Pg \pdfpageref\count1 \space \space 0 R %
-      /C /Normal %
       /K [#2] %
       /S #3 \space\LanguageCode>>}%
     }{%keine Seitenreferenz angeben
     \immediate \pdfobj useobjnum#1{<</Type /StructElem %
       /P #4\space 0 R %
-      /C /Normal %
       /K [#2] %
       /S #3>>}%
   }%


### PR DESCRIPTION
The .sty sets /Normal class (with /Start+EndIndent and /Space* attributes for
non-paragraphlike StructElemens Sect, Span, etc.  This problem can be
reproduced by using pdfinfo (from recent poppler-utils):

	pdfinfo -struct-text DemoAccMetaClass.pdf

	Syntax Warning: Wrong Attribute 'EndIndent' in element Sect
	Syntax Warning: Wrong Attribute 'SpaceAfter' in element Sect
	Syntax Warning: Wrong Attribute 'SpaceBefore' in element Sect
	Syntax Warning: Wrong Attribute 'StartIndent' in element Sect
	Syntax Warning: Wrong Attribute 'TextAlign' in element Sect
        ...

Fix this by removing the class from non-paragraph elements.