### PR TITLE
Remove extra percent sign (%) at \begin{verbatim}

### DIFF
--- a/DemoAccMetaClass.tex
+++ b/DemoAccMetaClass.tex
@@ -231,7 +231,7 @@ The \packagename{listings} package is one of several packages that can be used t
 
 Using an example from Werner posted on tex.stackexchange.com, we default to the \envname{verbatim} environment, and only use \packagename{listings} if we are compiling with \packagename{pdflatex}:
 
-\begin{verbatim}%
+\begin{verbatim}
 \makeatletter
 \@ifundefined{lstlisting}{}{%
   \let\verbatim\relax%
@@ -245,7 +245,7 @@ Using an example from Werner posted on tex.stackexchange.com, we default to the 
 
 \subsection{The final preamble}
 
-\begin{verbatim}%
+\begin{verbatim}
 \newif\iflatextortf
 
 \iflatextortf


### PR DESCRIPTION
The extra percent signs at two instances of "\begin{verbatim}" cause these
warnings:

(Package Listings)  Text dropped after begin of listing on input line 234.
(Package Listings)  Text dropped after begin of listing on input line 248.

Remove them to fix the warnings.