### PR TITLE
Fix internal hyperref names

### DIFF
--- a/DemoAccMetaClass.pdf
+++ b/DemoAccMetaClass.pdf
@@ -165,37 +165,37 @@ endobj
 (\376\377\000A\000\040\000w\000o\000r\000k\000f\000l\000o\000w\000\040\000f\000o\000r\000\040\000p\000r\000o\000d\000u\000c\000i\000n\000g\000\040\000a\000c\000c\000e\000s\000s\000i\000b\000l\000e\000\040\000.\000p\000d\000f\000\040\000f\000i\000l\000e\000s)
 endobj
 18 0 obj
-<< /S /GoTo /D (subsection.0.1) >>
+<< /S /GoTo /D (subsection.0.3.1) >>
 endobj
 21 0 obj
 (\376\377\000A\000\040\000`\000`\000m\000e\000t\000a\000'\000'\000\040\000L\000a\000T\000e\000X\000\040\000s\000t\000y\000l\000e\000\040\000f\000i\000l\000e)
 endobj
 22 0 obj
-<< /S /GoTo /D (subsection.0.2) >>
+<< /S /GoTo /D (subsection.0.3.2) >>
 endobj
 25 0 obj
 (\376\377\000A\000c\000c\000e\000s\000s\000i\000b\000i\000l\000i\000t\000y\000\040\000s\000u\000p\000p\000o\000r\000t)
 endobj
 26 0 obj
-<< /S /GoTo /D (subsubsection.0.3.1) >>
+<< /S /GoTo /D (subsubsection.0.3.2.1) >>
 endobj
 29 0 obj
 (\376\377\000A\000l\000t\000e\000r\000n\000a\000t\000i\000v\000e\000\040\000t\000e\000x\000t)
 endobj
 30 0 obj
-<< /S /GoTo /D (subsubsection.0.3.2) >>
+<< /S /GoTo /D (subsubsection.0.3.2.2) >>
 endobj
 33 0 obj
 (\376\377\000P\000r\000o\000b\000l\000e\000m\000s\000\040\000w\000i\000t\000h\000\040\000e\000m\000b\000e\000d\000d\000e\000d\000\040\000f\000o\000n\000t\000s)
 endobj
 34 0 obj
-<< /S /GoTo /D (subsection.0.3) >>
+<< /S /GoTo /D (subsection.0.3.3) >>
 endobj
 37 0 obj
 (\376\377\000A\000\040\000t\000e\000m\000p\000l\000a\000t\000e)
 endobj
 38 0 obj
-<< /S /GoTo /D (subsection.0.4) >>
+<< /S /GoTo /D (subsection.0.3.4) >>
 endobj
 41 0 obj
 (\376\377\000C\000h\000a\000n\000g\000i\000n\000g\000\040\000t\000o\000\040\000a\000\040\000W\000Y\000S\000I\000W\000Y\000G\000-\000r\000e\000a\000d\000a\000b\000l\000e\000\040\000f\000o\000r\000m\000a\000t\000\040\000u\000s\000i\000n\000g\000\040\000L\000a\000t\000e\000x\0002\000r\000t\000f)
@@ -207,36 +207,36 @@ endobj
 (\376\377\000U\000n\000i\000f\000i\000e\000d\000\040\000s\000o\000u\000r\000c\000e\000\040\000d\000o\000c\000u\000m\000e\000n\000t)
 endobj
 46 0 obj
-<< /S /GoTo /D (subsection.0.1) >>
-endobj
-48 0 obj
-(\376\377\000I\000n\000c\000l\000u\000d\000i\000n\000g\000\040\000c\000o\000d\000e\000\040\000l\000i\000s\000t\000i\000n\000g\000s)
+<< /S /GoTo /D (subsection.0.4.1) >>
 endobj
 49 0 obj
-<< /S /GoTo /D (subsection.0.2) >>
+(\376\377\000I\000n\000c\000l\000u\000d\000i\000n\000g\000\040\000c\000o\000d\000e\000\040\000l\000i\000s\000t\000i\000n\000g\000s)
 endobj
-51 0 obj
+50 0 obj
+<< /S /GoTo /D (subsection.0.4.2) >>
+endobj
+53 0 obj
 (\376\377\000T\000h\000e\000\040\000f\000i\000n\000a\000l\000\040\000p\000r\000e\000a\000m\000b\000l\000e)
 endobj
-52 0 obj
+54 0 obj
 << /S /GoTo /D (section.0.5) >>
 endobj
-55 0 obj
+57 0 obj
 (\376\377\000P\000r\000o\000b\000l\000e\000m\000s\000\040\000w\000i\000t\000h\000\040\000t\000h\000i\000s\000\040\000a\000p\000p\000r\000o\000a\000c\000h)
 endobj
-56 0 obj
+58 0 obj
 << /S /GoTo /D (section.0.6) >>
 endobj
-59 0 obj
+61 0 obj
 (\376\377\000C\000o\000n\000c\000l\000u\000s\000i\000o\000n\000s)
 endobj
-60 0 obj
-<< /S /GoTo /D [61 0 R /Fit] >>
+62 0 obj
+<< /S /GoTo /D [63 0 R /Fit] >>
 endobj
-64 0 obj
-<</Type /StructElem /P 63 0 R /K [ <</Type /MCR /Pg 61  0 R /MCID 0>>] /S /P /Lang(EN)>>
+66 0 obj
+<</Type /StructElem /P 65 0 R /K [ <</Type /MCR /Pg 63  0 R /MCID 0>>] /S /P /Lang(EN)>>
 endobj
-69 0 obj
+71 0 obj
 <<
 /Length 1207      
 >>
@@ -322,7 +322,7 @@ end
 
 endstream
 endobj
-70 0 obj
+72 0 obj
 <<
 /Length 1866      
 >>
@@ -446,7 +446,7 @@ end
 
 endstream
 endobj
-71 0 obj
+73 0 obj
 <<
 /Length 2370      
 >>
@@ -632,7 +632,7 @@ end
 
 endstream
 endobj
-72 0 obj
+74 0 obj
 <<
 /Length 3001      
 >>
@@ -833,117 +833,117 @@ end
 
 endstream
 endobj
+70 0 obj
+<</Type /StructElem /P 69 0 R /K [ <</Type /MCR /Pg 63  0 R /MCID 1>>] /S /TD /Lang(EN)  >>
+endobj
+69 0 obj
+<</Type /StructElem /P 68 0 R  /Lang(EN)/K [ 70 0 R] /S /TR>>
+endobj
 68 0 obj
-<</Type /StructElem /P 67 0 R /K [ <</Type /MCR /Pg 61  0 R /MCID 1>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 67 0 R  /Lang(EN)/K [ 69 0 R] /S /TBody>>
 endobj
 67 0 obj
-<</Type /StructElem /P 66 0 R  /Lang(EN)/K [ 68 0 R] /S /TR>>
-endobj
-66 0 obj
-<</Type /StructElem /P 65 0 R  /Lang(EN)/K [ 67 0 R] /S /TBody>>
+<</Type /StructElem /P 65 0 R  /Lang(EN)/K [ 68 0 R] /S /Table>>
 endobj
 65 0 obj
-<</Type /StructElem /P 63 0 R  /Lang(EN)/K [ 66 0 R] /S /Table>>
-endobj
-63 0 obj
-<</Type /StructElem /P 62 0 R /T (Titlepage) /Lang(EN)/K [ 64 0 R 65 0 R] /S /Div>>
-endobj
-73 0 obj
-<</Type /StructElem /P 62 0 R /K [ <</Type /MCR /Pg 61  0 R /MCID 2>>] /S /P /Lang(EN)>>
+<</Type /StructElem /P 64 0 R /T (Titlepage) /Lang(EN)/K [ 66 0 R 67 0 R] /S /Div>>
 endobj
 75 0 obj
-<</Type /StructElem /P 74 0 R /K [ <</Type /MCR /Pg 61  0 R /MCID 3>>] /S /H /Lang(EN)  >>
+<</Type /StructElem /P 64 0 R /K [ <</Type /MCR /Pg 63  0 R /MCID 2>>] /S /P /Lang(EN)>>
 endobj
 77 0 obj
-<</Type /StructElem /P 76 0 R /K <</Type /MCR /Pg 61  0 R /MCID 5>> /S /Span  /Lang(EN)  >>
-endobj
-78 0 obj
-<</Type /StructElem /P 76 0 R /K <</Type /MCR /Pg 61  0 R /MCID 7>> /S /Span  /Lang(EN)  >>
-endobj
-76 0 obj
-<</Type /StructElem /P 74 0 R /K [ <</Type /MCR /Pg 61  0 R /MCID 4>> 77 0 R <</Type /MCR /Pg 61  0 R /MCID 6>> 78 0 R <</Type /MCR /Pg 61  0 R /MCID 8>>] /S /P /Lang(EN)>>
+<</Type /StructElem /P 76 0 R /K [ <</Type /MCR /Pg 63  0 R /MCID 3>>] /S /H /Lang(EN)  >>
 endobj
 79 0 obj
-<</Type /StructElem /P 74 0 R /K [ <</Type /MCR /Pg 61  0 R /MCID 9>>] /S /P /Lang(EN)>>
-endobj
-81 0 obj
-<</Type /StructElem /P 80 0 R /K <</Type /MCR /Pg 61  0 R /MCID 10>> /S /TOCI  /Lang(EN)  >>
-endobj
-84 0 obj
-<</Type /StructElem /P 80 0 R /K <</Type /MCR /Pg 61  0 R /MCID 11>> /S /TOCI  /Lang(EN)  >>
-endobj
-87 0 obj
-<</Type /StructElem /P 80 0 R /K <</Type /MCR /Pg 61  0 R /MCID 12>> /S /TOCI  /Lang(EN)  >>
-endobj
-90 0 obj
-<</Type /StructElem /P 80 0 R /K <</Type /MCR /Pg 61  0 R /MCID 13>> /S /TOCI  /Lang(EN)  >>
-endobj
-93 0 obj
-<</Type /StructElem /P 80 0 R /K <</Type /MCR /Pg 61  0 R /MCID 14>> /S /TOCI  /Lang(EN)  >>
-endobj
-96 0 obj
-<</Type /StructElem /P 80 0 R /K <</Type /MCR /Pg 61  0 R /MCID 15>> /S /TOCI  /Lang(EN)  >>
-endobj
-99 0 obj
-<</Type /StructElem /P 80 0 R /K <</Type /MCR /Pg 61  0 R /MCID 16>> /S /TOCI  /Lang(EN)  >>
-endobj
-102 0 obj
-<</Type /StructElem /P 80 0 R /K <</Type /MCR /Pg 61  0 R /MCID 17>> /S /TOCI  /Lang(EN)  >>
-endobj
-105 0 obj
-<</Type /StructElem /P 80 0 R /K <</Type /MCR /Pg 61  0 R /MCID 18>> /S /TOCI  /Lang(EN)  >>
-endobj
-108 0 obj
-<</Type /StructElem /P 80 0 R /K <</Type /MCR /Pg 61  0 R /MCID 19>> /S /TOCI  /Lang(EN)  >>
-endobj
-111 0 obj
-<</Type /StructElem /P 80 0 R /K <</Type /MCR /Pg 61  0 R /MCID 20>> /S /TOCI  /Lang(EN)  >>
-endobj
-114 0 obj
-<</Type /StructElem /P 80 0 R /K <</Type /MCR /Pg 61  0 R /MCID 21>> /S /TOCI  /Lang(EN)  >>
-endobj
-117 0 obj
-<</Type /StructElem /P 80 0 R /K <</Type /MCR /Pg 61  0 R /MCID 22>> /S /TOCI  /Lang(EN)  >>
-endobj
-120 0 obj
-<</Type /StructElem /P 80 0 R /K <</Type /MCR /Pg 61  0 R /MCID 23>> /S /TOCI  /Lang(EN)  >>
+<</Type /StructElem /P 78 0 R /K <</Type /MCR /Pg 63  0 R /MCID 5>> /S /Span  /Lang(EN)  >>
 endobj
 80 0 obj
-<</Type /StructElem /P 74 0 R /K [ 81 0 R 84 0 R 87 0 R 90 0 R 93 0 R 96 0 R 99 0 R 102 0 R 105 0 R 108 0 R 111 0 R 114 0 R 117 0 R 120 0 R] /S /TOC /Lang(EN)  >>
+<</Type /StructElem /P 78 0 R /K <</Type /MCR /Pg 63  0 R /MCID 7>> /S /Span  /Lang(EN)  >>
 endobj
-123 0 obj
-<</Type /StructElem /P 74 0 R /K [ <</Type /MCR /Pg 61  0 R /MCID 24>>] /S /P /Lang(EN)>>
+78 0 obj
+<</Type /StructElem /P 76 0 R /K [ <</Type /MCR /Pg 63  0 R /MCID 4>> 79 0 R <</Type /MCR /Pg 63  0 R /MCID 6>> 80 0 R <</Type /MCR /Pg 63  0 R /MCID 8>>] /S /P /Lang(EN)>>
+endobj
+81 0 obj
+<</Type /StructElem /P 76 0 R /K [ <</Type /MCR /Pg 63  0 R /MCID 9>>] /S /P /Lang(EN)>>
+endobj
+83 0 obj
+<</Type /StructElem /P 82 0 R /K <</Type /MCR /Pg 63  0 R /MCID 10>> /S /TOCI  /Lang(EN)  >>
+endobj
+86 0 obj
+<</Type /StructElem /P 82 0 R /K <</Type /MCR /Pg 63  0 R /MCID 11>> /S /TOCI  /Lang(EN)  >>
+endobj
+89 0 obj
+<</Type /StructElem /P 82 0 R /K <</Type /MCR /Pg 63  0 R /MCID 12>> /S /TOCI  /Lang(EN)  >>
+endobj
+92 0 obj
+<</Type /StructElem /P 82 0 R /K <</Type /MCR /Pg 63  0 R /MCID 13>> /S /TOCI  /Lang(EN)  >>
+endobj
+95 0 obj
+<</Type /StructElem /P 82 0 R /K <</Type /MCR /Pg 63  0 R /MCID 14>> /S /TOCI  /Lang(EN)  >>
+endobj
+98 0 obj
+<</Type /StructElem /P 82 0 R /K <</Type /MCR /Pg 63  0 R /MCID 15>> /S /TOCI  /Lang(EN)  >>
+endobj
+101 0 obj
+<</Type /StructElem /P 82 0 R /K <</Type /MCR /Pg 63  0 R /MCID 16>> /S /TOCI  /Lang(EN)  >>
+endobj
+104 0 obj
+<</Type /StructElem /P 82 0 R /K <</Type /MCR /Pg 63  0 R /MCID 17>> /S /TOCI  /Lang(EN)  >>
+endobj
+107 0 obj
+<</Type /StructElem /P 82 0 R /K <</Type /MCR /Pg 63  0 R /MCID 18>> /S /TOCI  /Lang(EN)  >>
+endobj
+110 0 obj
+<</Type /StructElem /P 82 0 R /K <</Type /MCR /Pg 63  0 R /MCID 19>> /S /TOCI  /Lang(EN)  >>
+endobj
+113 0 obj
+<</Type /StructElem /P 82 0 R /K <</Type /MCR /Pg 63  0 R /MCID 20>> /S /TOCI  /Lang(EN)  >>
+endobj
+116 0 obj
+<</Type /StructElem /P 82 0 R /K <</Type /MCR /Pg 63  0 R /MCID 21>> /S /TOCI  /Lang(EN)  >>
+endobj
+119 0 obj
+<</Type /StructElem /P 82 0 R /K <</Type /MCR /Pg 63  0 R /MCID 22>> /S /TOCI  /Lang(EN)  >>
+endobj
+122 0 obj
+<</Type /StructElem /P 82 0 R /K <</Type /MCR /Pg 63  0 R /MCID 23>> /S /TOCI  /Lang(EN)  >>
+endobj
+82 0 obj
+<</Type /StructElem /P 76 0 R /K [ 83 0 R 86 0 R 89 0 R 92 0 R 95 0 R 98 0 R 101 0 R 104 0 R 107 0 R 110 0 R 113 0 R 116 0 R 119 0 R 122 0 R] /S /TOC /Lang(EN)  >>
 endobj
 125 0 obj
-<</Type /StructElem /P 124 0 R /K <</Type /MCR /Pg 61  0 R /MCID 25>> /S /TOFI  /Lang(EN)  >>
+<</Type /StructElem /P 76 0 R /K [ <</Type /MCR /Pg 63  0 R /MCID 24>>] /S /P /Lang(EN)>>
 endobj
-124 0 obj
-<</Type /StructElem /P 74 0 R /K [ 125 0 R] /S /TOF /Lang(EN)  >>
+127 0 obj
+<</Type /StructElem /P 126 0 R /K <</Type /MCR /Pg 63  0 R /MCID 25>> /S /TOFI  /Lang(EN)  >>
 endobj
-128 0 obj
-<</Type /StructElem /P 74 0 R /K [ <</Type /MCR /Pg 61  0 R /MCID 26>>] /S /P /Lang(EN)>>
+126 0 obj
+<</Type /StructElem /P 76 0 R /K [ 127 0 R] /S /TOF /Lang(EN)  >>
 endobj
 130 0 obj
-<</Type /StructElem /P 129 0 R /K <</Type /MCR /Pg 61  0 R /MCID 27>> /S /TOTI  /Lang(EN)  >>
+<</Type /StructElem /P 76 0 R /K [ <</Type /MCR /Pg 63  0 R /MCID 26>>] /S /P /Lang(EN)>>
 endobj
-129 0 obj
-<</Type /StructElem /P 74 0 R /K [ 130 0 R] /S /TOT /Lang(EN)  >>
+132 0 obj
+<</Type /StructElem /P 131 0 R /K <</Type /MCR /Pg 63  0 R /MCID 27>> /S /TOTI  /Lang(EN)  >>
 endobj
-74 0 obj
-<</Type /StructElem /P 62 0 R /T (Abstract) /Lang(EN)/K [ 75 0 R 76 0 R 79 0 R 80 0 R 123 0 R 124 0 R 128 0 R 129 0 R] /S /Section>>
+131 0 obj
+<</Type /StructElem /P 76 0 R /K [ 132 0 R] /S /TOT /Lang(EN)  >>
 endobj
-134 0 obj
-<</Type /StructElem /P 133 0 R /K [ <</Type /MCR /Pg 61  0 R /MCID 28>>] /S /H /Lang(EN)  >>
+76 0 obj
+<</Type /StructElem /P 64 0 R /T (Abstract) /Lang(EN)/K [ 77 0 R 78 0 R 81 0 R 82 0 R 125 0 R 126 0 R 130 0 R 131 0 R] /S /Section>>
 endobj
-135 0 obj
-<</Type /StructElem /P 133 0 R /K [ <</Type /MCR /Pg 61  0 R /MCID 29>>] /S /P /Lang(EN)>>
+136 0 obj
+<</Type /StructElem /P 135 0 R /K [ <</Type /MCR /Pg 63  0 R /MCID 28>>] /S /H /Lang(EN)  >>
 endobj
 137 0 obj
-<</Type /StructElem /P 136 0 R /K <</Type /MCR /Pg 61  0 R /MCID 31>> /S /Span  /Lang(EN)  >>
+<</Type /StructElem /P 135 0 R /K [ <</Type /MCR /Pg 63  0 R /MCID 29>>] /S /P /Lang(EN)>>
 endobj
 139 0 obj
+<</Type /StructElem /P 138 0 R /K <</Type /MCR /Pg 63  0 R /MCID 31>> /S /Span  /Lang(EN)  >>
+endobj
+141 0 obj
 <<
-/Length 40898     
+/Length 40995     
 >>
 stream
 0 g 0 G
@@ -955,339 +955,339 @@ stream
 /P <</MCID 0>> BDC
 1 0 0 1 -117.329 -642.157 cm
 BT
-/F79 17.2154 Tf 117.329 642.157 Td [(So)-250(you)-250(w)10(ant)-250(to)-250(replace)-250(your)-250(WYSIWYG)-250(w)10(ord)-250(proces-)]TJ -1.093 -21.918 Td [(sor)-250(with)-250(LaT)70(eX,)-250(b)20(ut)-250(508)-250(compliance)-250(has)-250(you)-250(stumped?)]TJ
+/F80 17.2154 Tf 117.329 642.157 Td [(So)-250(you)-250(w)10(ant)-250(to)-250(replace)-250(your)-250(WYSIWYG)-250(w)10(ord)-250(proces-)]TJ -1.093 -21.918 Td [(sor)-250(with)-250(LaT)70(eX,)-250(b)20(ut)-250(508)-250(compliance)-250(has)-250(you)-250(stumped?)]TJ
 ET
 1 0 0 1 72 601.568 cm
 EMC
 /TD <</MCID 1>> BDC
 1 0 0 1 -72 -601.568 cm
 BT
-/F79 11.9552 Tf 274.283 591.347 Td [(Andy)-250(Clifton)]TJ
+/F80 11.9552 Tf 274.283 591.347 Td [(Andy)-250(Clifton)]TJ
 ET
 1 0 0 1 343.694 591.347 cm
 EMC
-1 0 0 1 -65.585 -23.248 cm
+1 0 0 1 -102.193 -25.562 cm
 /P <</MCID 2>> BDC
-1 0 0 1 -278.109 -568.099 cm
+1 0 0 1 -241.501 -565.785 cm
 BT
-/F79 11.9552 Tf 278.109 568.099 Td [(2017-03-17)]TJ
+/F80 11.9552 Tf 241.501 565.785 Td [(Saturday)-250(18)]TJ/F80 8.9664 Tf 57.444 4.34 Td [(th)]TJ/F80 11.9552 Tf 10.463 -4.34 Td [(March,)-250(2017)]TJ
 0 g 0 G
 0 g 0 G
 ET
-1 0 0 1 72 553.035 cm
+1 0 0 1 72 548.253 cm
 EMC
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 1 0 0 1 0 -9.962 cm
 /H <</MCID 3>> BDC
-1 0 0 1 -72 -543.073 cm
+1 0 0 1 -72 -538.291 cm
 BT
-/F81 11.9552 Tf/F82 1 Tf( )Tj/F81 11.9552 Tf 72 543.073 Td [(Abstract)]TJ
+/F83 11.9552 Tf/F84 1 Tf( )Tj/F83 11.9552 Tf 72 538.291 Td [(Abstract)]TJ
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 g 0 G
 ET
-1 0 0 1 72 541.5 cm
+1 0 0 1 72 537.021 cm
 EMC
-1 0 0 1 0 -18.456 cm
+1 0 0 1 0 -17.784 cm
 /P <</MCID 4>> BDC
-1 0 0 1 -72 -523.044 cm
+1 0 0 1 -72 -519.237 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 523.044 Td [(`What)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.387 0 Td [(you)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(see)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.212 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(what)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(you)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(get')]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.983 0 Td [(\050WYSIWYG\051)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 58.37 0 Td [(w)10(ord)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.865 0 Td [(pro-)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 519.237 Td [(`What)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.387 0 Td [(you)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(see)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.212 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(what)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(you)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(get')]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.983 0 Td [(\050WYSIWYG\051)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 58.37 0 Td [(w)10(ord)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.865 0 Td [(pro-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -207.68 -11.955 Td [(cessors)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.262 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(frequently)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 43.437 0 Td [(used)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(within)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.955 0 Td [(or)18(g)5(anizations)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 55.939 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(pro-)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -207.68 -11.955 Td [(cessors)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.262 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(frequently)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 43.437 0 Td [(used)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(within)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.955 0 Td [(or)18(g)5(anizations)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 55.939 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(pro-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -204.242 -11.956 Td [(duce)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(PDF)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.762 0 Td [(documents)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.658 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(ha)20(v)15(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.951 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(common)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 37.36 0 Td [(look)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(feel.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -204.242 -11.955 Td [(duce)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(PDF)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.762 0 Td [(documents)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.658 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(ha)20(v)15(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.951 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(common)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 37.36 0 Td [(look)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(feel.)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -207.461 -11.955 Td [(The)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.983 0 Td [(PDFs)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.637 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(tagged,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.541 0 Td [(structured,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.822 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(pass)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.646 0 Td [(automated)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -207.461 -11.955 Td [(The)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.983 0 Td [(PDFs)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.637 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(tagged,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.541 0 Td [(structured,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.822 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(pass)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.646 0 Td [(automated)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -170.16 -11.955 Td [(tests)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(accessibility)65(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 54.186 0 Td [(PDFs)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.637 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(created)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -170.16 -11.956 Td [(tests)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(accessibility)65(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 54.186 0 Td [(PDFs)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.637 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(created)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -187.006 -11.955 Td [(with)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(L)]TJ/F79 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(do)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(not)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(pass)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.646 0 Td [(such)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(tests,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.694 0 Td [(making)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.379 0 Td [(it)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 8.029 0 Td [(dif)25(\002cult)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 33.793 0 Td [(to)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -187.006 -11.955 Td [(with)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(L)]TJ/F80 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.426 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(do)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(not)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(pass)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.646 0 Td [(such)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(tests,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.694 0 Td [(making)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.379 0 Td [(it)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 8.029 0 Td [(dif)25(\002cult)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 33.793 0 Td [(to)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -210.454 -11.955 Td [(use)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.771 0 Td [(L)]TJ/F79 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(corporate)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.109 0 Td [(en)40(vironment.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 55.542 0 Td [(This)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(e)15(x-)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -210.454 -11.955 Td [(use)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.771 0 Td [(L)]TJ/F80 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(corporate)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.109 0 Td [(en)40(vironment.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 55.542 0 Td [(This)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(e)15(x-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -215.845 -11.955 Td [(plains)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.291 0 Td [(ho)25(w)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.397 0 Td [(L)]TJ/F79 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.427 -2.242 Td [(E)]TJ 4.841 2.242 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(used)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(prepare)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.358 0 Td [(documents)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.658 0 Td [(that)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -215.845 -11.955 Td [(plains)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.291 0 Td [(ho)25(w)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.397 0 Td [(L)]TJ/F80 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.427 -2.242 Td [(E)]TJ 4.841 2.242 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(used)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(prepare)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.358 0 Td [(documents)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.658 0 Td [(that)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -208.193 -11.956 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(used)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(corporate)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.11 0 Td [(en)40(vironment.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 55.541 0 Td [(This)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.135 0 Td [(achie)25(v)15(ed)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -208.193 -11.955 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(used)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(corporate)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.11 0 Td [(en)40(vironment.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 55.541 0 Td [(This)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.135 0 Td [(achie)25(v)15(ed)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -191.111 -11.955 Td [(by)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.08 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.222 0 Td [(source)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.493 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.318 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.896 0 Td [(con)40(v)15(erted)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.225 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(an)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -191.111 -11.955 Td [(by)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.08 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.222 0 Td [(source)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.493 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.318 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.896 0 Td [(con)40(v)15(erted)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.225 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(an)]TJ
 ET
-1 0 0 1 278.414 415.447 cm
+1 0 0 1 278.414 411.641 cm
 EMC
 /Span <</MCID 5>> BDC
-1 0 0 1 -278.414 -415.447 cm
+1 0 0 1 -278.414 -411.641 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 278.414 415.447 Td [(.rtf)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 278.414 411.641 Td [(.rtf)]TJ
 ET
-1 0 0 1 291.774 415.447 cm
+1 0 0 1 291.774 411.641 cm
 EMC
 /P <</MCID 6>> BDC
 0 g 0 G
 0 g 0 G
-1 0 0 1 -291.774 -415.447 cm
+1 0 0 1 -291.774 -411.641 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 403.492 Td [(\002le,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.713 0 Td [(which)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.839 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.896 0 Td [(read)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.636 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(WYSIWYG)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 51.735 0 Td [(w)10(ord)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.865 0 Td [(pro-)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 399.685 Td [(\002le,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.713 0 Td [(which)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.839 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.896 0 Td [(read)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.636 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(WYSIWYG)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 51.735 0 Td [(w)10(ord)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.865 0 Td [(pro-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -194.4 -11.955 Td [(cessor)55(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.927 0 Td [(The)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.983 0 Td [(same)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.963 0 Td [(source)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.493 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(used)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(create)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -194.4 -11.955 Td [(cessor)55(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.927 0 Td [(The)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.983 0 Td [(same)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.963 0 Td [(source)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.493 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(used)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(create)]TJ
 ET
-1 0 0 1 256.845 391.537 cm
+1 0 0 1 256.845 387.73 cm
 EMC
 /Span <</MCID 7>> BDC
-1 0 0 1 -256.845 -391.537 cm
+1 0 0 1 -256.845 -387.73 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 256.845 391.537 Td [(.pdf)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 256.845 387.73 Td [(.pdf)]TJ
 ET
-1 0 0 1 273.522 391.537 cm
+1 0 0 1 273.522 387.73 cm
 EMC
 /P <</MCID 8>> BDC
-1 0 0 1 -273.522 -391.537 cm
+1 0 0 1 -273.522 -387.73 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 276.013 391.537 Td [(\002les)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 276.013 387.73 Td [(\002les)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -204.013 -11.955 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(satisfy)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.503 0 Td [(accessibility)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 51.745 0 Td [(requirements.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 57.593 0 Td [(This)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(is)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -204.013 -11.955 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(satisfy)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.503 0 Td [(accessibility)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 51.745 0 Td [(requirements.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 57.593 0 Td [(This)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(is)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -217.262 -11.955 Td [(intended)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.802 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(used)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(as)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(template)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.801 0 Td [(as)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(it)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 8.029 0 Td [(contains)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.696 0 Td [(most)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.868 0 Td [(of)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -217.262 -11.955 Td [(intended)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.802 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(used)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(as)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(template)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.801 0 Td [(as)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(it)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 8.029 0 Td [(contains)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.696 0 Td [(most)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.868 0 Td [(of)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -210.578 -11.956 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(elements)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 37.907 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(technical)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.455 0 Td [(L)]TJ/F79 7.3723 Tf 2.5 1.488 Td [(A)]TJ/F79 9.9626 Tf 3.829 -1.488 Td [(T)]TJ 4.426 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(document,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.273 0 Td [(including)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -210.578 -11.955 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(elements)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 37.907 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(technical)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.455 0 Td [(L)]TJ/F80 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(document,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.273 0 Td [(including)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -178.285 -11.955 Td [(comple)15(x)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.652 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(structures,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 43.716 0 Td [(lists,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.04 0 Td [(equations,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 43.168 0 Td [(\002gures)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -178.285 -11.955 Td [(comple)15(x)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.652 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(structures,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 43.716 0 Td [(lists,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.04 0 Td [(equations,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 43.168 0 Td [(\002gures)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -186.359 -11.955 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(code)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(listings.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -186.359 -11.956 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(code)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(listings.)]TJ
 0 g 0 G
 0 g 0 G
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 ET
-1 0 0 1 72 303.348 cm
+1 0 0 1 72 301.129 cm
 EMC
 /P <</MCID 9>> BDC
-1 0 0 1 -72 -303.348 cm
+1 0 0 1 -72 -301.129 cm
 BT
-/F81 11.9552 Tf/F82 1 Tf( )Tj/F81 11.9552 Tf 72 303.348 Td [(T)80(ab)10(le)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 33.474 0 Td [(of)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 14.609 0 Td [(Contents)]TJ
+/F83 11.9552 Tf/F84 1 Tf( )Tj/F83 11.9552 Tf 72 301.129 Td [(T)80(ab)10(le)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 33.474 0 Td [(of)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 14.609 0 Td [(Contents)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
 ET
-1 0 0 1 72 291.244 cm
+1 0 0 1 72 289.024 cm
 EMC
-1 0 0 1 14.94 -22.102 cm
+1 0 0 1 14.94 -21.766 cm
 /TOCI <</MCID 10>> BDC
 0 g 0 G
-1 0 0 1 -86.94 -269.142 cm
+1 0 0 1 -86.94 -267.258 cm
 BT
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 72 269.142 Td [(1)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 14.94 0 Td [(Intr)18(oduction)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 72 267.258 Td [(1)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 14.94 0 Td [(Intr)18(oduction)]TJ
 0 g 0 G
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 62.269 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 62.269 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ
 0 g 0 G
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 19.806 0 Td [(1)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 19.806 0 Td [(1)]TJ
 ET
-1 0 0 1 301.019 269.142 cm
+1 0 0 1 301.019 267.258 cm
 EMC
 0 g 0 G
 0 g 0 G
 0 g 0 G
-1 0 0 1 -214.079 -22.252 cm
+1 0 0 1 -214.079 -21.915 cm
 /TOCI <</MCID 11>> BDC
 0 g 0 G
-1 0 0 1 -86.94 -246.89 cm
+1 0 0 1 -86.94 -245.343 cm
 BT
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 72 246.89 Td [(2)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 14.94 0 Td [(Requir)18(ements)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 72 245.343 Td [(2)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 14.94 0 Td [(Requir)18(ements)]TJ
 0 g 0 G
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 62.269 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 62.269 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ
 0 g 0 G
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 19.806 0 Td [(2)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 19.806 0 Td [(2)]TJ
 ET
-1 0 0 1 301.019 246.89 cm
+1 0 0 1 301.019 245.343 cm
 EMC
 0 g 0 G
 0 g 0 G
 0 g 0 G
-1 0 0 1 -214.079 -22.252 cm
+1 0 0 1 -214.079 -21.916 cm
 /TOCI <</MCID 12>> BDC
 0 g 0 G
-1 0 0 1 -86.94 -224.638 cm
+1 0 0 1 -86.94 -223.427 cm
 BT
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 72 224.638 Td [(3)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 14.94 0 Td [(A)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 9.684 0 Td [(w)10(ork\003o)10(w)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 42.142 0 Td [(f)25(or)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 14.964 0 Td [(pr)18(oducing)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 46.046 0 Td [(accessible)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 43.995 0 Td [(.pdf)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 19.377 0 Td [(\002les)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 72 223.427 Td [(3)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 14.94 0 Td [(A)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 9.684 0 Td [(w)10(ork\003o)10(w)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 42.142 0 Td [(f)25(or)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 14.964 0 Td [(pr)18(oducing)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 46.046 0 Td [(accessible)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 43.995 0 Td [(.pdf)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 19.377 0 Td [(\002les)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F86 9.9626 Tf 32.889 0 Td [(2)]TJ
+/F84 1 Tf( )Tj/F88 9.9626 Tf 32.889 0 Td [(2)]TJ
 ET
-1 0 0 1 301.019 224.638 cm
+1 0 0 1 301.019 223.427 cm
 EMC
 0 g 0 G
 0 g 0 G
 0 g 0 G
-1 0 0 1 -176.23 -12.022 cm
+1 0 0 1 -176.23 -11.955 cm
 /TOCI <</MCID 13>> BDC
 0 g 0 G
-1 0 0 1 -124.789 -212.616 cm
+1 0 0 1 -124.789 -211.472 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 86.94 212.616 Td [(3.1)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.909 0 Td [(A)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.683 0 Td [(\223meta\224)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.705 0 Td [(LaT)70(eX)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.007 0 Td [(style)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.31 0 Td [(\002le)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 86.94 211.472 Td [(3.1)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.909 0 Td [(A)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.683 0 Td [(\223meta\224)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.705 0 Td [(LaT)70(eX)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.007 0 Td [(style)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.31 0 Td [(\002le)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 22.374 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 22.374 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 19.806 0 Td [(2)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 19.806 0 Td [(2)]TJ
 ET
-1 0 0 1 301.019 212.616 cm
+1 0 0 1 301.019 211.472 cm
 EMC
 0 g 0 G
 0 g 0 G
 0 g 0 G
-1 0 0 1 -176.23 -12.023 cm
+1 0 0 1 -176.23 -11.955 cm
 /TOCI <</MCID 14>> BDC
 0 g 0 G
-1 0 0 1 -124.789 -200.593 cm
+1 0 0 1 -124.789 -199.517 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 86.94 200.593 Td [(3.2)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.909 0 Td [(Accessibility)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 54.514 0 Td [(support)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 86.94 199.517 Td [(3.2)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.909 0 Td [(Accessibility)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 54.514 0 Td [(support)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 37.149 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 37.149 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 19.806 0 Td [(3)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 19.806 0 Td [(3)]TJ
 ET
-1 0 0 1 301.019 200.593 cm
+1 0 0 1 301.019 199.517 cm
 EMC
 0 g 0 G
 0 g 0 G
 0 g 0 G
-1 0 0 1 -121.449 -12.022 cm
+1 0 0 1 -121.449 -11.955 cm
 /TOCI <</MCID 15>> BDC
 0 g 0 G
-1 0 0 1 -179.57 -188.571 cm
+1 0 0 1 -179.57 -187.562 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 109.849 188.571 Td [(3.2.1)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.872 0 Td [(Alternati)25(v)15(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 46.914 0 Td [(te)15(xt)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 109.849 187.562 Td [(3.2.1)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.872 0 Td [(Alternati)25(v)15(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 46.914 0 Td [(te)15(xt)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 20.349 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 20.349 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 19.806 0 Td [(3)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 19.806 0 Td [(3)]TJ
 ET
-1 0 0 1 301.019 188.571 cm
+1 0 0 1 301.019 187.562 cm
 EMC
 0 g 0 G
 0 g 0 G
 0 g 0 G
-1 0 0 1 -121.449 -12.023 cm
+1 0 0 1 -121.449 -11.955 cm
 /TOCI <</MCID 16>> BDC
 0 g 0 G
-1 0 0 1 -179.57 -176.548 cm
+1 0 0 1 -179.57 -175.607 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 109.849 176.548 Td [(3.2.2)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.872 0 Td [(Problems)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.129 0 Td [(with)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(embedded)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 43.437 0 Td [(fonts)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 109.849 175.607 Td [(3.2.2)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.872 0 Td [(Problems)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.129 0 Td [(with)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(embedded)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 43.437 0 Td [(fonts)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 23.268 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 23.268 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 19.806 0 Td [(3)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 19.806 0 Td [(3)]TJ
 ET
-1 0 0 1 301.019 176.548 cm
+1 0 0 1 301.019 175.607 cm
 EMC
 0 g 0 G
 0 g 0 G
 0 g 0 G
-1 0 0 1 -176.23 -12.022 cm
+1 0 0 1 -176.23 -11.956 cm
 /TOCI <</MCID 17>> BDC
 0 g 0 G
-1 0 0 1 -124.789 -164.526 cm
+1 0 0 1 -124.789 -163.651 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 86.94 164.526 Td [(3.3)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.909 0 Td [(A)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.683 0 Td [(template)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 86.94 163.651 Td [(3.3)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.909 0 Td [(A)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.683 0 Td [(template)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 37.149 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 37.149 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 19.806 0 Td [(5)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 19.806 0 Td [(5)]TJ
 ET
-1 0 0 1 301.019 164.526 cm
+1 0 0 1 301.019 163.651 cm
 EMC
 0 g 0 G
 0 g 0 G
 0 g 0 G
-1 0 0 1 -176.23 -12.022 cm
+1 0 0 1 -176.23 -11.955 cm
 /TOCI <</MCID 18>> BDC
 0 g 0 G
-1 0 0 1 -124.789 -152.504 cm
+1 0 0 1 -124.789 -151.696 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 86.94 152.504 Td [(3.4)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.909 0 Td [(Changing)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.235 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(WYSIWYG-readable)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 88.797 0 Td [(for)20(-)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 86.94 151.696 Td [(3.4)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.909 0 Td [(Changing)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.235 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(WYSIWYG-readable)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 88.797 0 Td [(for)20(-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -147.187 -11.956 Td [(mat)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.08 0 Td [(Late)15(x2rtf)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -147.187 -11.955 Td [(mat)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.08 0 Td [(Late)15(x2rtf)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 42.677 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 42.677 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 19.806 0 Td [(5)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 19.806 0 Td [(5)]TJ
 ET
-1 0 0 1 301.019 140.548 cm
+1 0 0 1 301.019 139.741 cm
 EMC
 0 g 0 G
 0 g 0 G
 0 g 0 G
-1 0 0 1 -214.079 -22.251 cm
+1 0 0 1 -214.079 -21.915 cm
 /TOCI <</MCID 19>> BDC
 0 g 0 G
-1 0 0 1 -86.94 -118.297 cm
+1 0 0 1 -86.94 -117.826 cm
 BT
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 72 118.297 Td [(4)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 14.94 0 Td [(Uni\002ed)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 33.494 0 Td [(sour)18(ce)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 29.978 0 Td [(document)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 72 117.826 Td [(4)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 14.94 0 Td [(Uni\002ed)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 33.494 0 Td [(sour)18(ce)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 29.978 0 Td [(document)]TJ
 0 g 0 G
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 51.1 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 51.1 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ
 0 g 0 G
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 19.806 0 Td [(6)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 19.806 0 Td [(6)]TJ
 ET
-1 0 0 1 301.019 118.297 cm
+1 0 0 1 301.019 117.826 cm
 EMC
 0 g 0 G
 0 g 0 G
 0 g 0 G
-1 0 0 1 -176.23 -12.023 cm
+1 0 0 1 -176.23 -11.955 cm
 /TOCI <</MCID 20>> BDC
 0 g 0 G
-1 0 0 1 -124.789 -106.274 cm
+1 0 0 1 -124.789 -105.871 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 86.94 106.274 Td [(4.1)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.909 0 Td [(Including)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.677 0 Td [(code)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(listings)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 86.94 105.871 Td [(4.1)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.909 0 Td [(Including)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.677 0 Td [(code)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(listings)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 37.158 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 37.158 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 19.806 0 Td [(6)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 19.806 0 Td [(6)]TJ
 ET
-1 0 0 1 301.019 106.274 cm
+1 0 0 1 301.019 105.871 cm
 EMC
 0 g 0 G
 0 g 0 G
 0 g 0 G
-1 0 0 1 -176.23 -12.022 cm
+1 0 0 1 -176.23 -11.956 cm
 /TOCI <</MCID 21>> BDC
 0 g 0 G
-1 0 0 1 -124.789 -94.252 cm
+1 0 0 1 -124.789 -93.915 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 86.94 94.252 Td [(4.2)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.909 0 Td [(The)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.982 0 Td [(\002nal)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(preamble)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 86.94 93.915 Td [(4.2)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.909 0 Td [(The)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.982 0 Td [(\002nal)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(preamble)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 46.005 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 46.005 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 19.806 0 Td [(6)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 19.806 0 Td [(6)]TJ
 ET
-1 0 0 1 301.019 94.252 cm
+1 0 0 1 301.019 93.915 cm
 EMC
 0 g 0 G
 0 g 0 G
 0 g 0 G
-1 0 0 1 -214.079 -22.252 cm
+1 0 0 1 -214.079 -21.915 cm
 /TOCI <</MCID 22>> BDC
 0 g 0 G
 1 0 0 1 -86.94 -72 cm
 BT
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 72 72 Td [(5)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 14.94 0 Td [(Pr)18(oblems)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 42.71 0 Td [(with)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 21.31 0 Td [(this)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 17.992 0 Td [(appr)18(oach)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 72 72 Td [(5)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 14.94 0 Td [(Pr)18(oblems)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 42.71 0 Td [(with)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 21.31 0 Td [(this)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 17.992 0 Td [(appr)18(oach)]TJ
 0 g 0 G
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 47.504 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 47.504 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ
 0 g 0 G
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 19.806 0 Td [(7)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 19.806 0 Td [(7)]TJ
 ET
 1 0 0 1 301.019 72 cm
 EMC
@@ -1296,151 +1296,151 @@ EMC
 0 g 0 G
 0 g 0 G
 0 g 0 G
-1 0 0 1 24.903 471.073 cm
+1 0 0 1 24.903 466.291 cm
 /TOCI <</MCID 23>> BDC
 0 g 0 G
-1 0 0 1 -325.922 -543.073 cm
+1 0 0 1 -325.922 -538.291 cm
 BT
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 310.981 543.073 Td [(6)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 14.941 0 Td [(Conclusions)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 310.981 538.291 Td [(6)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 14.941 0 Td [(Conclusions)]TJ
 0 g 0 G
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 54.797 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 54.797 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ
 0 g 0 G
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 19.807 0 Td [(7)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 19.807 0 Td [(7)]TJ
 ET
-1 0 0 1 540 543.073 cm
+1 0 0 1 540 538.291 cm
 EMC
 0 g 0 G
 0 g 0 G
 0 g 0 G
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
-1 0 0 1 -229.019 -29.742 cm
+1 0 0 1 -229.019 -28.713 cm
 /P <</MCID 24>> BDC
-1 0 0 1 -310.981 -513.331 cm
+1 0 0 1 -310.981 -509.578 cm
 BT
-/F81 11.9552 Tf/F82 1 Tf( )Tj/F81 11.9552 Tf 310.981 513.331 Td [(List)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 24.58 0 Td [(of)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 14.609 0 Td [(Figures)]TJ
+/F83 11.9552 Tf/F84 1 Tf( )Tj/F83 11.9552 Tf 310.981 509.578 Td [(List)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 24.58 0 Td [(of)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 14.609 0 Td [(Figures)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
 ET
-1 0 0 1 310.981 498.716 cm
+1 0 0 1 310.981 494.963 cm
 EMC
 1 0 0 1 22.909 -14.277 cm
 /TOFI <</MCID 25>> BDC
-1 0 0 1 -333.89 -484.439 cm
+1 0 0 1 -333.89 -480.686 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 313.472 484.439 Td [(Figure)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 313.472 480.686 Td [(Figure)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 28.503 0 Td [(1.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.908 0 Td [(T)70(est)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.949 0 Td [(images)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 28.503 0 Td [(1.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.908 0 Td [(T)70(est)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.949 0 Td [(images)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 34.246 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 34.246 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 19.807 0 Td [(5)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 19.807 0 Td [(5)]TJ
 ET
-1 0 0 1 540 484.439 cm
+1 0 0 1 540 480.686 cm
 EMC
 0 g 0 G
 0 g 0 G
 0 g 0 G
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
-1 0 0 1 -229.019 -29.742 cm
+1 0 0 1 -229.019 -28.713 cm
 /P <</MCID 26>> BDC
-1 0 0 1 -310.981 -454.697 cm
+1 0 0 1 -310.981 -451.973 cm
 BT
-/F81 11.9552 Tf/F82 1 Tf( )Tj/F81 11.9552 Tf 310.981 454.697 Td [(List)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 24.58 0 Td [(of)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 14.609 0 Td [(T)80(ab)10(les)]TJ
+/F83 11.9552 Tf/F84 1 Tf( )Tj/F83 11.9552 Tf 310.981 451.973 Td [(List)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 24.58 0 Td [(of)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 14.609 0 Td [(T)80(ab)10(les)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
 ET
-1 0 0 1 310.981 442.593 cm
+1 0 0 1 310.981 439.868 cm
 EMC
 1 0 0 1 22.909 -16.787 cm
 /TOTI <</MCID 27>> BDC
-1 0 0 1 -333.89 -425.806 cm
+1 0 0 1 -333.89 -423.081 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 313.472 425.806 Td [(T)80(able)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 313.472 423.081 Td [(T)80(able)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 24.378 0 Td [(1.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.909 0 Td [(P)15(ackages)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.412 0 Td [(e)15(xplicitly)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.979 0 Td [(loaded)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.051 0 Td [(by)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 24.378 0 Td [(1.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.909 0 Td [(P)15(ackages)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.412 0 Td [(e)15(xplicitly)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.979 0 Td [(loaded)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.051 0 Td [(by)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(the)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -147.764 -11.955 Td [(meta)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(class)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -147.764 -11.955 Td [(meta)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(class)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 24.971 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.471 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 24.971 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.471 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(.)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf 19.807 0 Td [(4)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf 19.807 0 Td [(4)]TJ
 ET
-1 0 0 1 540 413.851 cm
+1 0 0 1 540 411.126 cm
 EMC
 0 g 0 G
 0 g 0 G
 0 g 0 G
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
-1 0 0 1 -229.019 -38.69 cm
+1 0 0 1 -229.019 -37.136 cm
 /H <</MCID 28>> BDC
-1 0 0 1 -310.981 -375.161 cm
+1 0 0 1 -310.981 -373.99 cm
 BT
-/F81 11.9552 Tf/F82 1 Tf( )Tj/F81 11.9552 Tf 310.981 375.161 Td [(1)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 18.602 0 Td [(Intr)20(oduction)]TJ
+/F83 11.9552 Tf/F84 1 Tf( )Tj/F83 11.9552 Tf 310.981 373.99 Td [(1)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 18.602 0 Td [(Intr)20(oduction)]TJ
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 g 0 G
 ET
-1 0 0 1 310.981 373.311 cm
+1 0 0 1 310.981 372.355 cm
 EMC
-1 0 0 1 0 -19.074 cm
+1 0 0 1 0 -18.596 cm
 /P <</MCID 29>> BDC
-1 0 0 1 -310.981 -354.237 cm
+1 0 0 1 -310.981 -353.759 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 354.237 Td [(The)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.983 0 Td [(de-f)10(acto)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.028 0 Td [(standard)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.244 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(scienti\002c)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.465 0 Td [(publishing)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.562 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(L)]TJ/F79 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 353.759 Td [(The)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.983 0 Td [(de-f)10(acto)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.028 0 Td [(standard)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.244 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(scienti\002c)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.465 0 Td [(publishing)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.562 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(L)]TJ/F80 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X.)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -211.122 -11.955 Td [(L)]TJ/F79 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.427 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.683 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(often)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.963 0 Td [(preferred)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.994 0 Td [(o)15(v)15(er)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.895 0 Td [(WYSIWYG)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 51.736 0 Td [(w)10(ord)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.864 0 Td [(proces-)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -211.122 -11.955 Td [(L)]TJ/F80 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.427 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.683 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(often)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.963 0 Td [(preferred)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.994 0 Td [(o)15(v)15(er)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.895 0 Td [(WYSIWYG)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 51.736 0 Td [(w)10(ord)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.864 0 Td [(proces-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -190.869 -11.955 Td [(sors)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.54 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(technical)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.456 0 Td [(documents)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.658 0 Td [(because)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.022 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.664 0 Td [(relati)25(v)15(ely)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -190.869 -11.955 Td [(sors)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.54 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(technical)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.456 0 Td [(documents)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.658 0 Td [(because)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.022 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.664 0 Td [(relati)25(v)15(ely)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -176.237 -11.956 Td [(simple)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.061 0 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.222 0 Td [(format)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.051 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.896 0 Td [(shared)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.492 0 Td [(across)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.387 0 Td [(users)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.964 0 Td [(on)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -176.237 -11.956 Td [(simple)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.061 0 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.222 0 Td [(format)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.051 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.896 0 Td [(shared)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.492 0 Td [(across)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.387 0 Td [(users)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.964 0 Td [(on)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -197.826 -11.955 Td [(man)15(y)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.478 0 Td [(dif)25(ferent)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.543 0 Td [(platforms,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 43.167 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(ease)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.636 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(formatting)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -197.826 -11.955 Td [(man)15(y)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.478 0 Td [(dif)25(ferent)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.543 0 Td [(platforms,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 43.167 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(ease)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.636 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(formatting)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -166.155 -11.955 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(journal)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.715 0 Td [(publication.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 50.41 0 Td [(In)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(contrast,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.522 0 Td [(man)15(y)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -166.155 -11.955 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(journal)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.715 0 Td [(publication.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 50.41 0 Td [(In)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(contrast,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.522 0 Td [(man)15(y)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -191.241 -11.955 Td [(or)18(g)5(anizations)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 55.94 0 Td [(ha)20(v)15(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.951 0 Td [(publishing)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.563 0 Td [(w)10(ork\003o)25(ws)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.204 0 Td [(b)20(uilt)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.562 0 Td [(around)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -191.241 -11.955 Td [(or)18(g)5(anizations)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 55.94 0 Td [(ha)20(v)15(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.951 0 Td [(publishing)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.563 0 Td [(w)10(ork\003o)25(ws)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.204 0 Td [(b)20(uilt)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.562 0 Td [(around)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -186.22 -11.955 Td [(WYSIWYG)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 51.736 0 Td [(tools,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.358 0 Td [(which)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.839 0 Td [(often)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.964 0 Td [(include)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.82 0 Td [(PDF)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.762 0 Td [(creators.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -186.22 -11.955 Td [(WYSIWYG)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 51.736 0 Td [(tools,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.358 0 Td [(which)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.839 0 Td [(often)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.964 0 Td [(include)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.82 0 Td [(PDF)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.762 0 Td [(creators.)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -178.479 -11.956 Td [(WYSIWYG)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 51.736 0 Td [(w)10(ord)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.864 0 Td [(processing)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.1 0 Td [(tools)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.868 0 Td [(often)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.964 0 Td [(include)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.82 0 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -178.479 -11.956 Td [(WYSIWYG)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 51.736 0 Td [(w)10(ord)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.864 0 Td [(processing)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.1 0 Td [(tools)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.868 0 Td [(often)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.964 0 Td [(include)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.82 0 Td [(the)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -196.352 -11.955 Td [(ability)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.955 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(edit)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(track)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.406 0 Td [(input)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.974 0 Td [(from)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.857 0 Td [(co-)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -196.352 -11.955 Td [(ability)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.955 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(edit)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(track)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.406 0 Td [(input)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.974 0 Td [(from)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.857 0 Td [(co-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -188.441 -11.955 Td [(w)10(ork)10(ers)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.381 0 Td [(or)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(dedicated)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.667 0 Td [(editors,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.1 0 Td [(which)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.839 0 Td [(simpli\002es)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.244 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(re)25(vie)25(w)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -188.441 -11.955 Td [(w)10(ork)10(ers)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.381 0 Td [(or)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(dedicated)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.667 0 Td [(editors,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.1 0 Td [(which)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.839 0 Td [(simpli\002es)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.244 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(re)25(vie)25(w)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -200.685 -11.955 Td [(process.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.457 0 Td [(Although)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.129 0 Td [(changes)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.58 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(compared)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.773 0 Td [(between)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -200.685 -11.955 Td [(process.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.457 0 Td [(Although)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.129 0 Td [(changes)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.58 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(compared)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.773 0 Td [(between)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -180.153 -11.955 Td [(L)]TJ/F79 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.427 -2.242 Td [(E)]TJ 4.841 2.242 Td [(Xdocuments)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 52.852 0 Td [(using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.079 0 Td [(command)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(line)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(tools,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.359 0 Td [(editors)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.608 0 Td [(in)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -180.153 -11.955 Td [(L)]TJ/F80 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.427 -2.242 Td [(E)]TJ 4.841 2.242 Td [(Xdocuments)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 52.852 0 Td [(using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.079 0 Td [(command)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(line)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(tools,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.359 0 Td [(editors)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.608 0 Td [(in)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -205.712 -11.955 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(corporate)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.109 0 Td [(en)40(vironment)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 52.453 0 Td [(may)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.646 0 Td [(lack)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.089 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.664 0 Td [(training)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 33.484 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(edit)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -205.712 -11.955 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(corporate)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.109 0 Td [(en)40(vironment)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 52.453 0 Td [(may)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.646 0 Td [(lack)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.089 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.664 0 Td [(training)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 33.484 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(edit)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -196.601 -11.956 Td [(L)]TJ/F79 7.3723 Tf 2.501 1.488 Td [(A)]TJ/F79 9.9626 Tf 3.828 -1.488 Td [(T)]TJ 4.426 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(source)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.493 0 Td [(\002les.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.186 0 Td [(So,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.502 0 Td [(L)]TJ/F79 7.3723 Tf 2.501 1.488 Td [(A)]TJ/F79 9.9626 Tf 3.828 -1.488 Td [(T)]TJ 4.426 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(does)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(not)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(\002t)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.799 0 Td [(well)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.646 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(corpo-)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -196.601 -11.956 Td [(L)]TJ/F80 7.3723 Tf 2.501 1.488 Td [(A)]TJ/F80 9.9626 Tf 3.828 -1.488 Td [(T)]TJ 4.426 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(source)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.493 0 Td [(\002les.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.186 0 Td [(So,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.502 0 Td [(L)]TJ/F80 7.3723 Tf 2.501 1.488 Td [(A)]TJ/F80 9.9626 Tf 3.828 -1.488 Td [(T)]TJ 4.426 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(does)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(not)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(\002t)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.799 0 Td [(well)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.646 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(corpo-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -200.319 -11.955 Td [(rate)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.424 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(preparation)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 47.86 0 Td [(w)10(ork\003o)25(w)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.329 0 Td [(unless)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.397 0 Td [(L)]TJ/F79 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(\002les)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -200.319 -11.955 Td [(rate)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.424 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(preparation)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 47.86 0 Td [(w)10(ork\003o)25(w)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.329 0 Td [(unless)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.397 0 Td [(L)]TJ/F80 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(\002les)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -200.074 -11.955 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(con)40(v)15(erted)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.225 0 Td [(into)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.993 0 Td [(something)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.004 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(read)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.637 0 Td [(by)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(a)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -200.074 -11.955 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(con)40(v)15(erted)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.225 0 Td [(into)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.993 0 Td [(something)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.004 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(read)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.637 0 Td [(by)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(a)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -209.174 -11.955 Td [(WYSIWYG)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 51.736 0 Td [(editor)55(.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -209.174 -11.955 Td [(WYSIWYG)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 51.736 0 Td [(editor)55(.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -1449,36 +1449,36 @@ EMC
 /P <</MCID 30>> BDC
 1 0 0 1 -310.981 -131.776 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 131.776 Td [(Another)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.138 0 Td [(issue)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.416 0 Td [(with)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.079 0 Td [(L)]TJ/F79 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.427 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.344 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(document)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 131.776 Td [(Another)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.138 0 Td [(issue)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.416 0 Td [(with)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.079 0 Td [(L)]TJ/F80 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.427 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.344 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(document)]TJ
 ET
 1 0 0 1 490.679 131.776 cm
 EMC
 /Span <</MCID 31>> BDC
 1 0 0 1 -490.679 -131.776 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 490.679 131.776 Td [(accessi-)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 490.679 131.776 Td [(accessi-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F85 9.9626 Tf -179.698 -11.955 Td [(bility)]TJ
+/F84 1 Tf( )Tj/F87 9.9626 Tf -179.698 -11.955 Td [(bility)]TJ
 ET
 1 0 0 1 331.464 119.821 cm
 EMC
 /P <</MCID 32>> BDC
 1 0 0 1 -331.464 -119.821 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 331.464 119.821 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 5.579 0 Td [(Accessibility)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 54.515 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.135 0 Td [(important)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.235 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(documents)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.658 0 Td [(pro-)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 331.464 119.821 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 5.579 0 Td [(Accessibility)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 54.515 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.135 0 Td [(important)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.235 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(documents)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.658 0 Td [(pro-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -190.712 -11.955 Td [(duced)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.282 0 Td [(by)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(federally-funded)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 68.881 0 Td [(or)18(g)5(anizations:)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 59.307 0 Td [(since)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.964 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.664 0 Td [(US)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -190.712 -11.956 Td [(duced)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.282 0 Td [(by)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(federally-funded)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 68.881 0 Td [(or)18(g)5(anizations:)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 59.307 0 Td [(since)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.964 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.664 0 Td [(US)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -204.551 -11.956 Td [(Congress)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.572 0 Td [(passed)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.05 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(1998)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.416 0 Td [(Section)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.378 0 Td [(508)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(Amendment)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 51.745 0 Td [(to)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -204.551 -11.955 Td [(Congress)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.572 0 Td [(passed)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.05 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(1998)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.416 0 Td [(Section)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.378 0 Td [(508)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(Amendment)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 51.745 0 Td [(to)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -207.261 -11.955 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(Rehabilitation)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 58.948 0 Td [(Act)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(1973,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.907 0 Td [(it)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 8.029 0 Td [(has)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.771 0 Td [(been)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(requirement)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -207.261 -11.955 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(Rehabilitation)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 58.948 0 Td [(Act)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(1973,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.907 0 Td [(it)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 8.029 0 Td [(has)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.771 0 Td [(been)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(requirement)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -178.2 -11.955 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(all)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(federally-funded)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 68.881 0 Td [(documents)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.658 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(accessible)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 42.878 0 Td [(to)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -178.2 -11.955 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(all)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(federally-funded)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 68.881 0 Td [(documents)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.658 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(accessible)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 42.878 0 Td [(to)]TJ
 0 g 0 G
 ET
 1 0 0 1 310.981 72 cm
@@ -1489,7 +1489,7 @@ EMC
 /Artifact <</Type /Pagination>> BDC
 1 0 0 1 -72 -42.112 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 303.509 42.112 Td [(1)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 303.509 42.112 Td [(1)]TJ
 ET
 1 0 0 1 540 42.112 cm
 EMC
@@ -1497,31 +1497,22 @@ EMC
 
 endstream
 endobj
-61 0 obj
+63 0 obj
 <<
 /Type /Page
-/Contents 139 0 R
-/Resources 138 0 R
+/Contents 141 0 R
+/Resources 140 0 R
 /MediaBox [0 0 612 792]
-/Parent 152 0 R
-/Annots [ 82 0 R 83 0 R 85 0 R 86 0 R 88 0 R 89 0 R 91 0 R 92 0 R 94 0 R 95 0 R 97 0 R 98 0 R 100 0 R 101 0 R 103 0 R 104 0 R 106 0 R 148 0 R 149 0 R 107 0 R 109 0 R 110 0 R 112 0 R 113 0 R 115 0 R 116 0 R 118 0 R 119 0 R 121 0 R 122 0 R 126 0 R 127 0 R 131 0 R 150 0 R 151 0 R 132 0 R ]
+/Parent 154 0 R
+/Annots [ 84 0 R 85 0 R 87 0 R 88 0 R 90 0 R 91 0 R 93 0 R 94 0 R 96 0 R 97 0 R 99 0 R 100 0 R 102 0 R 103 0 R 105 0 R 106 0 R 108 0 R 150 0 R 151 0 R 109 0 R 111 0 R 112 0 R 114 0 R 115 0 R 117 0 R 118 0 R 120 0 R 121 0 R 123 0 R 124 0 R 128 0 R 129 0 R 133 0 R 152 0 R 153 0 R 134 0 R ]
 >>
 endobj
-82 0 obj
+84 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [71.004 268.026 142.003 277.002]
-/A << /S /GoTo /D (section.0.1) >>
->>
-endobj
-83 0 obj
-<<
-/Type /Annot
-/Subtype /Link
-/F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [295.041 268.145 302.015 277.002]
+/Rect [71.004 266.142 142.003 275.118]
 /A << /S /GoTo /D (section.0.1) >>
 >>
 endobj
@@ -1530,16 +1521,16 @@ endobj
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [71.004 243.871 147.522 254.75]
-/A << /S /GoTo /D (section.0.2) >>
+/Rect [295.041 266.262 302.015 275.118]
+/A << /S /GoTo /D (section.0.1) >>
 >>
 endobj
-86 0 obj
+87 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [295.041 245.894 302.015 254.75]
+/Rect [71.004 242.324 147.522 253.203]
 /A << /S /GoTo /D (section.0.2) >>
 >>
 endobj
@@ -1548,16 +1539,16 @@ endobj
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [71.004 221.619 280.752 232.499]
-/A << /S /GoTo /D (section.0.3) >>
+/Rect [295.041 244.346 302.015 253.203]
+/A << /S /GoTo /D (section.0.2) >>
 >>
 endobj
-89 0 obj
+90 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [295.041 223.642 302.015 232.499]
+/Rect [71.004 220.409 280.752 231.288]
 /A << /S /GoTo /D (section.0.3) >>
 >>
 endobj
@@ -1566,17 +1557,17 @@ endobj
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [85.944 209.463 215.282 220.367]
-/A << /S /GoTo /D (subsection.0.1) >>
+/Rect [295.041 222.431 302.015 231.288]
+/A << /S /GoTo /D (section.0.3) >>
 >>
 endobj
-92 0 obj
+93 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [295.041 211.619 302.015 220.367]
-/A << /S /GoTo /D (subsection.0.1) >>
+/Rect [85.944 208.319 215.282 219.223]
+/A << /S /GoTo /D (subsection.0.3.1) >>
 >>
 endobj
 94 0 obj
@@ -1584,17 +1575,17 @@ endobj
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [85.944 197.44 195.247 208.344]
-/A << /S /GoTo /D (subsection.0.2) >>
+/Rect [295.041 210.476 302.015 219.223]
+/A << /S /GoTo /D (subsection.0.3.1) >>
 >>
 endobj
-95 0 obj
+96 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [295.041 199.497 302.015 208.344]
-/A << /S /GoTo /D (subsection.0.2) >>
+/Rect [85.944 196.364 195.247 207.268]
+/A << /S /GoTo /D (subsection.0.3.2) >>
 >>
 endobj
 97 0 obj
@@ -1602,17 +1593,17 @@ endobj
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [108.853 187.475 204.426 196.322]
-/A << /S /GoTo /D (subsubsection.0.3.1) >>
+/Rect [295.041 198.421 302.015 207.268]
+/A << /S /GoTo /D (subsection.0.3.2) >>
 >>
 endobj
-98 0 obj
+99 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [295.041 187.475 302.015 196.322]
-/A << /S /GoTo /D (subsubsection.0.3.1) >>
+/Rect [108.853 186.466 204.426 195.313]
+/A << /S /GoTo /D (subsubsection.0.3.2.1) >>
 >>
 endobj
 100 0 obj
@@ -1620,17 +1611,17 @@ endobj
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [108.853 175.453 266.413 184.299]
-/A << /S /GoTo /D (subsubsection.0.3.2) >>
+/Rect [295.041 186.466 302.015 195.313]
+/A << /S /GoTo /D (subsubsection.0.3.2.1) >>
 >>
 endobj
-101 0 obj
+102 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [295.041 175.453 302.015 184.299]
-/A << /S /GoTo /D (subsubsection.0.3.2) >>
+/Rect [108.853 174.511 266.413 183.357]
+/A << /S /GoTo /D (subsubsection.0.3.2.2) >>
 >>
 endobj
 103 0 obj
@@ -1638,17 +1629,17 @@ endobj
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [85.944 161.373 154.839 172.277]
-/A << /S /GoTo /D (subsection.0.3) >>
+/Rect [295.041 174.511 302.015 183.357]
+/A << /S /GoTo /D (subsubsection.0.3.2.2) >>
 >>
 endobj
-104 0 obj
+105 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [295.041 163.43 302.015 172.277]
-/A << /S /GoTo /D (subsection.0.3) >>
+/Rect [85.944 160.498 154.839 171.402]
+/A << /S /GoTo /D (subsection.0.3.3) >>
 >>
 endobj
 106 0 obj
@@ -1656,35 +1647,35 @@ endobj
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [85.944 149.35 302.015 160.254]
-/A << /S /GoTo /D (subsection.0.4) >>
+/Rect [295.041 162.556 302.015 171.402]
+/A << /S /GoTo /D (subsection.0.3.3) >>
 >>
 endobj
-148 0 obj
+108 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [71.004 149.35 72.996 153.5]
-/A << /S /GoTo /D (subsection.0.4) >>
+/Rect [85.944 148.543 302.015 159.447]
+/A << /S /GoTo /D (subsection.0.3.4) >>
 >>
 endobj
-149 0 obj
+150 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [71.004 137.395 189.28 148.299]
-/A << /S /GoTo /D (subsection.0.4) >>
+/Rect [71.004 148.543 72.996 152.693]
+/A << /S /GoTo /D (subsection.0.3.4) >>
 >>
 endobj
-107 0 obj
+151 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [295.041 139.453 302.015 148.299]
-/A << /S /GoTo /D (subsection.0.4) >>
+/Rect [71.004 136.588 189.28 147.492]
+/A << /S /GoTo /D (subsection.0.3.4) >>
 >>
 endobj
 109 0 obj
@@ -1692,16 +1683,16 @@ endobj
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [71.004 117.181 193.47 126.157]
-/A << /S /GoTo /D (section.0.4) >>
+/Rect [295.041 138.645 302.015 147.492]
+/A << /S /GoTo /D (subsection.0.3.4) >>
 >>
 endobj
-110 0 obj
+111 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [295.041 117.181 302.015 126.157]
+/Rect [71.004 116.71 193.47 125.686]
 /A << /S /GoTo /D (section.0.4) >>
 >>
 endobj
@@ -1710,17 +1701,17 @@ endobj
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [85.944 103.121 201.614 114.025]
-/A << /S /GoTo /D (subsection.0.1) >>
+/Rect [295.041 116.71 302.015 125.686]
+/A << /S /GoTo /D (section.0.4) >>
 >>
 endobj
-113 0 obj
+114 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [295.041 105.178 302.015 114.025]
-/A << /S /GoTo /D (subsection.0.1) >>
+/Rect [85.944 102.717 201.614 113.621]
+/A << /S /GoTo /D (subsection.0.4.1) >>
 >>
 endobj
 115 0 obj
@@ -1728,20 +1719,29 @@ endobj
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [85.944 91.099 186.102 102.003]
-/A << /S /GoTo /D (subsection.0.2) >>
+/Rect [295.041 104.775 302.015 113.621]
+/A << /S /GoTo /D (subsection.0.4.1) >>
 >>
 endobj
-116 0 obj
+117 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [295.041 93.156 302.015 102.003]
-/A << /S /GoTo /D (subsection.0.2) >>
+/Rect [85.944 90.762 186.102 101.666]
+/A << /S /GoTo /D (subsection.0.4.2) >>
 >>
 endobj
 118 0 obj
+<<
+/Type /Annot
+/Subtype /Link
+/F 4/Border[0 0 0]/H/I/C[1 0 0]
+/Rect [295.041 92.82 302.015 101.666]
+/A << /S /GoTo /D (subsection.0.4.2) >>
+>>
+endobj
+120 0 obj
 <<
 /Type /Annot
 /Subtype /Link
@@ -1750,7 +1750,7 @@ endobj
 /A << /S /GoTo /D (section.0.5) >>
 >>
 endobj
-119 0 obj
+121 0 obj
 <<
 /Type /Annot
 /Subtype /Link
@@ -1759,325 +1759,325 @@ endobj
 /A << /S /GoTo /D (section.0.5) >>
 >>
 endobj
-121 0 obj
+123 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [309.985 541.957 378.404 550.933]
+/Rect [309.985 537.175 378.404 546.151]
 /A << /S /GoTo /D (section.0.6) >>
 >>
 endobj
-122 0 obj
+124 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [534.022 542.076 540.996 550.933]
+/Rect [534.022 537.294 540.996 546.151]
 /A << /S /GoTo /D (section.0.6) >>
 >>
 endobj
-126 0 obj
+128 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [340.979 481.286 413.052 492.19]
+/Rect [340.979 477.533 413.052 488.437]
 /A << /S /GoTo /D (figure.caption.3) >>
 >>
 endobj
-127 0 obj
+129 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [534.022 483.343 540.996 492.19]
+/Rect [534.022 479.59 540.996 488.437]
 /A << /S /GoTo /D (figure.caption.3) >>
 >>
 endobj
-131 0 obj
+133 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [336.854 422.653 540.996 433.557]
+/Rect [336.854 419.928 540.996 430.832]
 /A << /S /GoTo /D (table.caption.2) >>
 >>
 endobj
-150 0 obj
+152 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [309.985 422.653 311.978 426.802]
+/Rect [309.985 419.928 311.978 424.077]
 /A << /S /GoTo /D (table.caption.2) >>
 >>
 endobj
-151 0 obj
+153 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [309.985 412.755 376.111 421.601]
+/Rect [309.985 410.03 376.111 418.877]
 /A << /S /GoTo /D (table.caption.2) >>
 >>
 endobj
-132 0 obj
+134 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
-/Rect [534.022 412.854 540.996 421.601]
+/Rect [534.022 410.13 540.996 418.877]
 /A << /S /GoTo /D (table.caption.2) >>
->>
-endobj
-140 0 obj
-<<
-/D [61 0 R /XYZ 71 718.907 null]
 >>
 endobj
 142 0 obj
 <<
-/D [61 0 R /XYZ 72 553.035 null]
+/D [63 0 R /XYZ 71 718.907 null]
 >>
 endobj
-143 0 obj
+144 0 obj
 <<
-/D [61 0 R /XYZ 72 557.02 null]
+/D [63 0 R /XYZ 72 548.253 null]
+>>
+endobj
+145 0 obj
+<<
+/D [63 0 R /XYZ 72 552.238 null]
 >>
 endobj
 7 0 obj
 <<
-/D [61 0 R /XYZ 310.981 396.277 null]
+/D [63 0 R /XYZ 310.981 394.628 null]
 >>
 endobj
-138 0 obj
+140 0 obj
 <<
  /ColorSpace 3 0 R /Pattern 2 0 R /ExtGState 1 0 R 
-/Font << /F79 141 0 R /F81 144 0 R /F82 145 0 R /F85 146 0 R /F86 147 0 R >>
+/Font << /F80 143 0 R /F83 146 0 R /F84 147 0 R /F87 148 0 R /F88 149 0 R >>
 /ProcSet [ /PDF /Text ]
 >>
 endobj
-136 0 obj
-<</Type /StructElem /P 133 0 R /K [ <</Type /MCR /Pg 61  0 R /MCID 30>> 137 0 R <</Type /MCR /Pg 61  0 R /MCID 32>> <</Type /MCR /Pg 155 0 R /MCID 33>>] /S /P /Lang(EN)>>
-endobj
-158 0 obj
-<</Type /StructElem /P 157 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 34>>] /S /Lbl /Lang(EN)  >>
-endobj
-159 0 obj
-<</Type /StructElem /P 157 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 35>>] /S /LBody /Lang(EN)  >>
-endobj
-157 0 obj
-<</Type /StructElem /P 156 0 R  /Lang(EN)/K [ 158 0 R 159 0 R] /S /LI>>
-endobj
-161 0 obj
-<</Type /StructElem /P 160 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 36>>] /S /Lbl /Lang(EN)  >>
-endobj
-162 0 obj
-<</Type /StructElem /P 160 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 37>>] /S /LBody /Lang(EN)  >>
+138 0 obj
+<</Type /StructElem /P 135 0 R /K [ <</Type /MCR /Pg 63  0 R /MCID 30>> 139 0 R <</Type /MCR /Pg 63  0 R /MCID 32>> <</Type /MCR /Pg 157 0 R /MCID 33>>] /S /P /Lang(EN)>>
 endobj
 160 0 obj
-<</Type /StructElem /P 156 0 R  /Lang(EN)/K [ 161 0 R 162 0 R] /S /LI>>
+<</Type /StructElem /P 159 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 34>>] /S /Lbl /Lang(EN)  >>
 endobj
-164 0 obj
-<</Type /StructElem /P 163 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 38>>] /S /Lbl /Lang(EN)  >>
+161 0 obj
+<</Type /StructElem /P 159 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 35>>] /S /LBody /Lang(EN)  >>
 endobj
-165 0 obj
-<</Type /StructElem /P 163 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 39>>] /S /LBody /Lang(EN)  >>
+159 0 obj
+<</Type /StructElem /P 158 0 R  /Lang(EN)/K [ 160 0 R 161 0 R] /S /LI>>
 endobj
 163 0 obj
-<</Type /StructElem /P 156 0 R  /Lang(EN)/K [ 164 0 R 165 0 R] /S /LI>>
+<</Type /StructElem /P 162 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 36>>] /S /Lbl /Lang(EN)  >>
 endobj
-167 0 obj
-<</Type /StructElem /P 166 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 40>>] /S /Lbl /Lang(EN)  >>
+164 0 obj
+<</Type /StructElem /P 162 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 37>>] /S /LBody /Lang(EN)  >>
 endobj
-168 0 obj
-<</Type /StructElem /P 166 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 41>>] /S /LBody /Lang(EN)  >>
+162 0 obj
+<</Type /StructElem /P 158 0 R  /Lang(EN)/K [ 163 0 R 164 0 R] /S /LI>>
 endobj
 166 0 obj
-<</Type /StructElem /P 156 0 R  /Lang(EN)/K [ 167 0 R 168 0 R] /S /LI>>
+<</Type /StructElem /P 165 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 38>>] /S /Lbl /Lang(EN)  >>
 endobj
-170 0 obj
-<</Type /StructElem /P 169 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 42>>] /S /Lbl /Lang(EN)  >>
+167 0 obj
+<</Type /StructElem /P 165 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 39>>] /S /LBody /Lang(EN)  >>
 endobj
-171 0 obj
-<</Type /StructElem /P 169 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 43>>] /S /LBody /Lang(EN)  >>
+165 0 obj
+<</Type /StructElem /P 158 0 R  /Lang(EN)/K [ 166 0 R 167 0 R] /S /LI>>
 endobj
 169 0 obj
-<</Type /StructElem /P 156 0 R  /Lang(EN)/K [ 170 0 R 171 0 R] /S /LI>>
+<</Type /StructElem /P 168 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 40>>] /S /Lbl /Lang(EN)  >>
 endobj
-156 0 obj
-<</Type /StructElem /P 133 0 R  /Lang(EN)/K [ 157 0 R 160 0 R 163 0 R 166 0 R 169 0 R] /S /L1>>
+170 0 obj
+<</Type /StructElem /P 168 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 41>>] /S /LBody /Lang(EN)  >>
 endobj
-173 0 obj
-<</Type /StructElem /P 172 0 R /K <</Type /MCR /Pg 155  0 R /MCID 45>> /S /Span  /Lang(EN)  >>
-endobj
-174 0 obj
-<</Type /StructElem /P 172 0 R /K <</Type /MCR /Pg 155  0 R /MCID 47>> /S /Span  /Lang(EN)  >>
+168 0 obj
+<</Type /StructElem /P 158 0 R  /Lang(EN)/K [ 169 0 R 170 0 R] /S /LI>>
 endobj
 172 0 obj
-<</Type /StructElem /P 133 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 44>> 173 0 R <</Type /MCR /Pg 155  0 R /MCID 46>> 174 0 R <</Type /MCR /Pg 155  0 R /MCID 48>>] /S /P /Lang(EN)>>
+<</Type /StructElem /P 171 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 42>>] /S /Lbl /Lang(EN)  >>
 endobj
-176 0 obj
-<</Type /StructElem /P 175 0 R /K <</Type /MCR /Pg 155  0 R /MCID 50>> /S /Span  /Lang(EN)  >>
+173 0 obj
+<</Type /StructElem /P 171 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 43>>] /S /LBody /Lang(EN)  >>
 endobj
-177 0 obj
-<</Type /StructElem /P 175 0 R /K <</Type /MCR /Pg 155  0 R /MCID 52>> /S /Span  /Lang(EN)  >>
+171 0 obj
+<</Type /StructElem /P 158 0 R  /Lang(EN)/K [ 172 0 R 173 0 R] /S /LI>>
+endobj
+158 0 obj
+<</Type /StructElem /P 135 0 R  /Lang(EN)/K [ 159 0 R 162 0 R 165 0 R 168 0 R 171 0 R] /S /L1>>
 endobj
 175 0 obj
-<</Type /StructElem /P 133 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 49>> 176 0 R <</Type /MCR /Pg 155  0 R /MCID 51>> 177 0 R <</Type /MCR /Pg 155  0 R /MCID 53>>] /S /P /Lang(EN)>>
+<</Type /StructElem /P 174 0 R /K <</Type /MCR /Pg 157  0 R /MCID 45>> /S /Span  /Lang(EN)  >>
 endobj
-133 0 obj
-<</Type /StructElem /P 62 0 R /T (Introduction) /Lang(EN)/K [ 134 0 R 135 0 R 136 0 R 156 0 R 172 0 R 175 0 R] /S /Section>>
+176 0 obj
+<</Type /StructElem /P 174 0 R /K <</Type /MCR /Pg 157  0 R /MCID 47>> /S /Span  /Lang(EN)  >>
 endobj
-179 0 obj
-<</Type /StructElem /P 178 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 54>>] /S /H /Lang(EN)  >>
-endobj
-180 0 obj
-<</Type /StructElem /P 178 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 55>>] /S /P /Lang(EN)>>
-endobj
-183 0 obj
-<</Type /StructElem /P 182 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 56>>] /S /Lbl /Lang(EN)  >>
-endobj
-184 0 obj
-<</Type /StructElem /P 182 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 57>>] /S /LBody /Lang(EN)  >>
-endobj
-182 0 obj
-<</Type /StructElem /P 181 0 R  /Lang(EN)/K [ 183 0 R 184 0 R] /S /LI>>
-endobj
-186 0 obj
-<</Type /StructElem /P 185 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 58>>] /S /Lbl /Lang(EN)  >>
-endobj
-187 0 obj
-<</Type /StructElem /P 185 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 59>>] /S /LBody /Lang(EN)  >>
-endobj
-185 0 obj
-<</Type /StructElem /P 181 0 R  /Lang(EN)/K [ 186 0 R 187 0 R] /S /LI>>
-endobj
-189 0 obj
-<</Type /StructElem /P 188 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 60>>] /S /Lbl /Lang(EN)  >>
-endobj
-190 0 obj
-<</Type /StructElem /P 188 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 61>>] /S /LBody /Lang(EN)  >>
-endobj
-188 0 obj
-<</Type /StructElem /P 181 0 R  /Lang(EN)/K [ 189 0 R 190 0 R] /S /LI>>
-endobj
-181 0 obj
-<</Type /StructElem /P 178 0 R  /Lang(EN)/K [ 182 0 R 185 0 R 188 0 R] /S /L1>>
+174 0 obj
+<</Type /StructElem /P 135 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 44>> 175 0 R <</Type /MCR /Pg 157  0 R /MCID 46>> 176 0 R <</Type /MCR /Pg 157  0 R /MCID 48>>] /S /P /Lang(EN)>>
 endobj
 178 0 obj
-<</Type /StructElem /P 62 0 R /T (Requirements) /Lang(EN)/K [ 179 0 R 180 0 R 181 0 R] /S /Section>>
+<</Type /StructElem /P 177 0 R /K <</Type /MCR /Pg 157  0 R /MCID 50>> /S /Span  /Lang(EN)  >>
+endobj
+179 0 obj
+<</Type /StructElem /P 177 0 R /K <</Type /MCR /Pg 157  0 R /MCID 52>> /S /Span  /Lang(EN)  >>
+endobj
+177 0 obj
+<</Type /StructElem /P 135 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 49>> 178 0 R <</Type /MCR /Pg 157  0 R /MCID 51>> 179 0 R <</Type /MCR /Pg 157  0 R /MCID 53>>] /S /P /Lang(EN)>>
+endobj
+135 0 obj
+<</Type /StructElem /P 64 0 R /T (Introduction) /Lang(EN)/K [ 136 0 R 137 0 R 138 0 R 158 0 R 174 0 R 177 0 R] /S /Section>>
+endobj
+181 0 obj
+<</Type /StructElem /P 180 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 54>>] /S /H /Lang(EN)  >>
+endobj
+182 0 obj
+<</Type /StructElem /P 180 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 55>>] /S /P /Lang(EN)>>
+endobj
+185 0 obj
+<</Type /StructElem /P 184 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 56>>] /S /Lbl /Lang(EN)  >>
+endobj
+186 0 obj
+<</Type /StructElem /P 184 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 57>>] /S /LBody /Lang(EN)  >>
+endobj
+184 0 obj
+<</Type /StructElem /P 183 0 R  /Lang(EN)/K [ 185 0 R 186 0 R] /S /LI>>
+endobj
+188 0 obj
+<</Type /StructElem /P 187 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 58>>] /S /Lbl /Lang(EN)  >>
+endobj
+189 0 obj
+<</Type /StructElem /P 187 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 59>>] /S /LBody /Lang(EN)  >>
+endobj
+187 0 obj
+<</Type /StructElem /P 183 0 R  /Lang(EN)/K [ 188 0 R 189 0 R] /S /LI>>
+endobj
+191 0 obj
+<</Type /StructElem /P 190 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 60>>] /S /Lbl /Lang(EN)  >>
 endobj
 192 0 obj
-<</Type /StructElem /P 191 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 62>>] /S /H /Lang(EN)  >>
+<</Type /StructElem /P 190 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 61>>] /S /LBody /Lang(EN)  >>
 endobj
-193 0 obj
-<</Type /StructElem /P 191 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 63>>] /S /P /Lang(EN)>>
+190 0 obj
+<</Type /StructElem /P 183 0 R  /Lang(EN)/K [ 191 0 R 192 0 R] /S /LI>>
 endobj
-196 0 obj
-<</Type /StructElem /P 195 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 64>>] /S /Lbl /Lang(EN)  >>
+183 0 obj
+<</Type /StructElem /P 180 0 R  /Lang(EN)/K [ 184 0 R 187 0 R 190 0 R] /S /L1>>
 endobj
-198 0 obj
-<</Type /StructElem /P 197 0 R /K <</Type /MCR /Pg 155  0 R /MCID 66>> /S /Span  /Lang(EN)  >>
-endobj
-197 0 obj
-<</Type /StructElem /P 195 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 65>> 198 0 R <</Type /MCR /Pg 155  0 R /MCID 67>>] /S /LBody /Lang(EN)  >>
-endobj
-195 0 obj
-<</Type /StructElem /P 194 0 R  /Lang(EN)/K [ 196 0 R 197 0 R] /S /LI>>
-endobj
-200 0 obj
-<</Type /StructElem /P 199 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 68>>] /S /Lbl /Lang(EN)  >>
-endobj
-202 0 obj
-<</Type /StructElem /P 201 0 R /K <</Type /MCR /Pg 155  0 R /MCID 70>> /S /Span  /Lang(EN)  >>
-endobj
-201 0 obj
-<</Type /StructElem /P 199 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 69>> 202 0 R <</Type /MCR /Pg 155  0 R /MCID 71>>] /S /LBody /Lang(EN)  >>
-endobj
-199 0 obj
-<</Type /StructElem /P 194 0 R  /Lang(EN)/K [ 200 0 R 201 0 R] /S /LI>>
-endobj
-204 0 obj
-<</Type /StructElem /P 203 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 72>>] /S /Lbl /Lang(EN)  >>
-endobj
-205 0 obj
-<</Type /StructElem /P 203 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 73>>] /S /LBody /Lang(EN)  >>
-endobj
-203 0 obj
-<</Type /StructElem /P 194 0 R  /Lang(EN)/K [ 204 0 R 205 0 R] /S /LI>>
-endobj
-207 0 obj
-<</Type /StructElem /P 206 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 74>>] /S /Lbl /Lang(EN)  >>
-endobj
-208 0 obj
-<</Type /StructElem /P 206 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 75>>] /S /LBody /Lang(EN)  >>
-endobj
-206 0 obj
-<</Type /StructElem /P 194 0 R  /Lang(EN)/K [ 207 0 R 208 0 R] /S /LI>>
-endobj
-210 0 obj
-<</Type /StructElem /P 209 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 76>>] /S /Lbl /Lang(EN)  >>
-endobj
-211 0 obj
-<</Type /StructElem /P 209 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 77>>] /S /LBody /Lang(EN)  >>
-endobj
-209 0 obj
-<</Type /StructElem /P 194 0 R  /Lang(EN)/K [ 210 0 R 211 0 R] /S /LI>>
-endobj
-213 0 obj
-<</Type /StructElem /P 212 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 78>>] /S /Lbl /Lang(EN)  >>
-endobj
-214 0 obj
-<</Type /StructElem /P 212 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 79>>] /S /LBody /Lang(EN)  >>
-endobj
-212 0 obj
-<</Type /StructElem /P 194 0 R  /Lang(EN)/K [ 213 0 R 214 0 R] /S /LI>>
-endobj
-216 0 obj
-<</Type /StructElem /P 215 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 80>>] /S /Lbl /Lang(EN)  >>
-endobj
-217 0 obj
-<</Type /StructElem /P 215 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 81>>] /S /LBody /Lang(EN)  >>
-endobj
-215 0 obj
-<</Type /StructElem /P 194 0 R  /Lang(EN)/K [ 216 0 R 217 0 R] /S /LI>>
-endobj
-219 0 obj
-<</Type /StructElem /P 218 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 82>>] /S /Lbl /Lang(EN)  >>
-endobj
-220 0 obj
-<</Type /StructElem /P 218 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 83>>] /S /LBody /Lang(EN)  >>
-endobj
-218 0 obj
-<</Type /StructElem /P 194 0 R  /Lang(EN)/K [ 219 0 R 220 0 R] /S /LI>>
+180 0 obj
+<</Type /StructElem /P 64 0 R /T (Requirements) /Lang(EN)/K [ 181 0 R 182 0 R 183 0 R] /S /Section>>
 endobj
 194 0 obj
-<</Type /StructElem /P 191 0 R  /Lang(EN)/K [ 195 0 R 199 0 R 203 0 R 206 0 R 209 0 R 212 0 R 215 0 R 218 0 R] /S /L1>>
+<</Type /StructElem /P 193 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 62>>] /S /H /Lang(EN)  >>
+endobj
+195 0 obj
+<</Type /StructElem /P 193 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 63>>] /S /P /Lang(EN)>>
+endobj
+198 0 obj
+<</Type /StructElem /P 197 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 64>>] /S /Lbl /Lang(EN)  >>
+endobj
+200 0 obj
+<</Type /StructElem /P 199 0 R /K <</Type /MCR /Pg 157  0 R /MCID 66>> /S /Span  /Lang(EN)  >>
+endobj
+199 0 obj
+<</Type /StructElem /P 197 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 65>> 200 0 R <</Type /MCR /Pg 157  0 R /MCID 67>>] /S /LBody /Lang(EN)  >>
+endobj
+197 0 obj
+<</Type /StructElem /P 196 0 R  /Lang(EN)/K [ 198 0 R 199 0 R] /S /LI>>
+endobj
+202 0 obj
+<</Type /StructElem /P 201 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 68>>] /S /Lbl /Lang(EN)  >>
+endobj
+204 0 obj
+<</Type /StructElem /P 203 0 R /K <</Type /MCR /Pg 157  0 R /MCID 70>> /S /Span  /Lang(EN)  >>
+endobj
+203 0 obj
+<</Type /StructElem /P 201 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 69>> 204 0 R <</Type /MCR /Pg 157  0 R /MCID 71>>] /S /LBody /Lang(EN)  >>
+endobj
+201 0 obj
+<</Type /StructElem /P 196 0 R  /Lang(EN)/K [ 202 0 R 203 0 R] /S /LI>>
+endobj
+206 0 obj
+<</Type /StructElem /P 205 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 72>>] /S /Lbl /Lang(EN)  >>
+endobj
+207 0 obj
+<</Type /StructElem /P 205 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 73>>] /S /LBody /Lang(EN)  >>
+endobj
+205 0 obj
+<</Type /StructElem /P 196 0 R  /Lang(EN)/K [ 206 0 R 207 0 R] /S /LI>>
+endobj
+209 0 obj
+<</Type /StructElem /P 208 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 74>>] /S /Lbl /Lang(EN)  >>
+endobj
+210 0 obj
+<</Type /StructElem /P 208 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 75>>] /S /LBody /Lang(EN)  >>
+endobj
+208 0 obj
+<</Type /StructElem /P 196 0 R  /Lang(EN)/K [ 209 0 R 210 0 R] /S /LI>>
+endobj
+212 0 obj
+<</Type /StructElem /P 211 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 76>>] /S /Lbl /Lang(EN)  >>
+endobj
+213 0 obj
+<</Type /StructElem /P 211 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 77>>] /S /LBody /Lang(EN)  >>
+endobj
+211 0 obj
+<</Type /StructElem /P 196 0 R  /Lang(EN)/K [ 212 0 R 213 0 R] /S /LI>>
+endobj
+215 0 obj
+<</Type /StructElem /P 214 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 78>>] /S /Lbl /Lang(EN)  >>
+endobj
+216 0 obj
+<</Type /StructElem /P 214 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 79>>] /S /LBody /Lang(EN)  >>
+endobj
+214 0 obj
+<</Type /StructElem /P 196 0 R  /Lang(EN)/K [ 215 0 R 216 0 R] /S /LI>>
+endobj
+218 0 obj
+<</Type /StructElem /P 217 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 80>>] /S /Lbl /Lang(EN)  >>
+endobj
+219 0 obj
+<</Type /StructElem /P 217 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 81>>] /S /LBody /Lang(EN)  >>
+endobj
+217 0 obj
+<</Type /StructElem /P 196 0 R  /Lang(EN)/K [ 218 0 R 219 0 R] /S /LI>>
 endobj
 221 0 obj
-<</Type /StructElem /P 191 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 84>>] /S /P /Lang(EN)>>
+<</Type /StructElem /P 220 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 82>>] /S /Lbl /Lang(EN)  >>
 endobj
 222 0 obj
-<</Type /StructElem /P 191 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 85>>] /S /P /Lang(EN)>>
+<</Type /StructElem /P 220 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 83>>] /S /LBody /Lang(EN)  >>
+endobj
+220 0 obj
+<</Type /StructElem /P 196 0 R  /Lang(EN)/K [ 221 0 R 222 0 R] /S /LI>>
+endobj
+196 0 obj
+<</Type /StructElem /P 193 0 R  /Lang(EN)/K [ 197 0 R 201 0 R 205 0 R 208 0 R 211 0 R 214 0 R 217 0 R 220 0 R] /S /L1>>
+endobj
+223 0 obj
+<</Type /StructElem /P 193 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 84>>] /S /P /Lang(EN)>>
 endobj
 224 0 obj
-<</Type /StructElem /P 223 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 86>>] /S /H /Lang(EN)  >>
+<</Type /StructElem /P 193 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 85>>] /S /P /Lang(EN)>>
 endobj
 226 0 obj
-<</Type /StructElem /P 225 0 R /K <</Type /MCR /Pg 155  0 R /MCID 88>> /S /Span  /Lang(EN)  >>
+<</Type /StructElem /P 225 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 86>>] /S /H /Lang(EN)  >>
+endobj
+228 0 obj
+<</Type /StructElem /P 227 0 R /K <</Type /MCR /Pg 157  0 R /MCID 88>> /S /Span  /Lang(EN)  >>
+endobj
+229 0 obj
+<</Type /StructElem /P 227 0 R /K [<</Type /MCR /Pg 157  0 R /MCID 90>> <</Type /OBJR /Obj 230 0 R>>] /S /Reference>>
 endobj
 227 0 obj
-<</Type /StructElem /P 225 0 R /K [<</Type /MCR /Pg 155  0 R /MCID 90>> <</Type /OBJR /Obj 228 0 R>>] /S /Reference>>
-endobj
-225 0 obj
-<</Type /StructElem /P 223 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 87>> 226 0 R <</Type /MCR /Pg 155  0 R /MCID 89>>227 0 R   <</Type /MCR /Pg 155  0 R /MCID 91>>] /S /P /Lang(EN)>>
-endobj
-230 0 obj
-<</Type /StructElem /P 229 0 R /K <</Type /MCR /Pg 155  0 R /MCID 93>> /S /Span  /Lang(EN)  >>
+<</Type /StructElem /P 225 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 87>> 228 0 R <</Type /MCR /Pg 157  0 R /MCID 89>>229 0 R   <</Type /MCR /Pg 157  0 R /MCID 91>>] /S /P /Lang(EN)>>
 endobj
 232 0 obj
+<</Type /StructElem /P 231 0 R /K <</Type /MCR /Pg 157  0 R /MCID 93>> /S /Span  /Lang(EN)  >>
+endobj
+234 0 obj
 <<
 /Length 45078     
 >>
@@ -2088,10 +2088,10 @@ stream
 /P <</MCID 33>> BDC
 1 0 0 1 -72 -684 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 674.037 Td [(people)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.051 0 Td [(with)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(disabilities.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 48.756 0 Td [(An)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(accessible)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 42.878 0 Td [(PDF)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.762 0 Td [(has)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.771 0 Td [(se)25(v)15(eral)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 674.037 Td [(people)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.051 0 Td [(with)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(disabilities.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 48.756 0 Td [(An)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(accessible)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 42.878 0 Td [(PDF)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.762 0 Td [(has)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.771 0 Td [(se)25(v)15(eral)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -192.087 -11.955 Td [(characteristics:)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -192.087 -11.955 Td [(characteristics:)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -2102,7 +2102,7 @@ EMC
 /Lbl <</MCID 34>> BDC
 1 0 0 1 -80.966 -642.768 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 83.457 642.768 Td [(\225)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 83.457 642.768 Td [(\225)]TJ
 ET
 1 0 0 1 86.944 642.768 cm
 EMC
@@ -2111,7 +2111,7 @@ EMC
 /LBody <</MCID 35>> BDC
 1 0 0 1 -91.925 -642.768 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 91.925 642.768 Td [(All)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(content)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.821 0 Td [(has)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.77 0 Td [(been)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(tagged)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 91.925 642.768 Td [(All)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(content)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.821 0 Td [(has)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.77 0 Td [(been)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(tagged)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -2121,7 +2121,7 @@ EMC
 /Lbl <</MCID 36>> BDC
 1 0 0 1 -80.966 -623.454 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 83.457 623.454 Td [(\225)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 83.457 623.454 Td [(\225)]TJ
 ET
 1 0 0 1 86.944 623.454 cm
 EMC
@@ -2130,10 +2130,10 @@ EMC
 /LBody <</MCID 37>> BDC
 1 0 0 1 -91.925 -623.454 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 91.925 623.454 Td [(It)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 8.578 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(possible)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.147 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(de\002ne)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.839 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(reading)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.368 0 Td [(order)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.512 0 Td [(based)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.175 0 Td [(on)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 91.925 623.454 Td [(It)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 8.578 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(possible)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.147 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(de\002ne)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.839 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(reading)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.368 0 Td [(order)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.512 0 Td [(based)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.175 0 Td [(on)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -177.911 -11.955 Td [(those)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.522 0 Td [(tags)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -177.911 -11.955 Td [(those)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.522 0 Td [(tags)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -2143,7 +2143,7 @@ EMC
 /Lbl <</MCID 38>> BDC
 1 0 0 1 -80.966 -592.185 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 83.457 592.185 Td [(\225)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 83.457 592.185 Td [(\225)]TJ
 ET
 1 0 0 1 86.944 592.185 cm
 EMC
@@ -2152,10 +2152,10 @@ EMC
 /LBody <</MCID 39>> BDC
 1 0 0 1 -91.925 -592.185 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 91.925 592.185 Td [(Images)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.263 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(links)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.868 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(gi)25(v)15(en)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.229 0 Td [(alternate)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.791 0 Td [(te)15(xt)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.285 0 Td [(descrip-)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 91.925 592.185 Td [(Images)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.263 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(links)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.868 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(gi)25(v)15(en)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.229 0 Td [(alternate)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.791 0 Td [(te)15(xt)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.285 0 Td [(descrip-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -162.967 -11.955 Td [(tions)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -162.967 -11.955 Td [(tions)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -2165,7 +2165,7 @@ EMC
 /Lbl <</MCID 40>> BDC
 1 0 0 1 -80.966 -560.916 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 83.457 560.916 Td [(\225)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 83.457 560.916 Td [(\225)]TJ
 ET
 1 0 0 1 86.944 560.916 cm
 EMC
@@ -2174,10 +2174,10 @@ EMC
 /LBody <</MCID 41>> BDC
 1 0 0 1 -91.925 -560.916 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 91.925 560.916 Td [(T)80(ables)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.254 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(tagged,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.541 0 Td [(so)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.348 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(table)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(structure)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 37.349 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(be)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 91.925 560.916 Td [(T)80(ables)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.254 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(tagged,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.541 0 Td [(so)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.348 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(table)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(structure)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 37.349 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(be)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -193.423 -11.955 Td [(established)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -193.423 -11.955 Td [(established)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -2187,7 +2187,7 @@ EMC
 /Lbl <</MCID 42>> BDC
 1 0 0 1 -80.966 -529.647 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 83.457 529.647 Td [(\225)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 83.457 529.647 Td [(\225)]TJ
 ET
 1 0 0 1 86.944 529.647 cm
 EMC
@@ -2196,7 +2196,7 @@ EMC
 /LBody <</MCID 43>> BDC
 1 0 0 1 -91.925 -529.647 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 91.925 529.647 Td [(Unicode)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.244 0 Td [(descriptions)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 50.64 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(all)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(characters)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 42.869 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(required)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 91.925 529.647 Td [(Unicode)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.244 0 Td [(descriptions)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 50.64 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(all)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(characters)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 42.869 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(required)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -2206,62 +2206,62 @@ EMC
 /P <</MCID 44>> BDC
 1 0 0 1 -72 -510.333 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 510.333 Td [(A)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(has)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.771 0 Td [(these)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.963 0 Td [(characteristics)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 59.476 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(often)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.963 0 Td [(re-)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 510.333 Td [(A)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(has)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.771 0 Td [(these)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.963 0 Td [(characteristics)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 59.476 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(often)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.963 0 Td [(re-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -199.21 -11.955 Td [(ferred)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.271 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(as)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(being)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.628 0 Td [(`508)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(compliant'.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 48.746 0 Td [(This)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(adds)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(another)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -199.21 -11.955 Td [(ferred)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.271 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(as)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(being)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.628 0 Td [(`508)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(compliant'.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 48.746 0 Td [(This)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(adds)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(another)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -182.384 -11.956 Td [(challenge)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.667 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.664 0 Td [(use)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.771 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(L)]TJ/F79 7.3723 Tf 2.5 1.488 Td [(A)]TJ/F79 9.9626 Tf 3.829 -1.488 Td [(T)]TJ 4.426 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.683 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(corporate)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.109 0 Td [(en)40(viron-)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -182.384 -11.956 Td [(challenge)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.667 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.664 0 Td [(use)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.771 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(L)]TJ/F80 7.3723 Tf 2.5 1.488 Td [(A)]TJ/F80 9.9626 Tf 3.829 -1.488 Td [(T)]TJ 4.426 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.683 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(corporate)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.109 0 Td [(en)40(viron-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -174.679 -11.955 Td [(ment:)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.783 0 Td [(not)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(only)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(does)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(need)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.896 0 Td [(con)40(v)15(erted)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -174.679 -11.955 Td [(ment:)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.783 0 Td [(not)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(only)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(does)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(need)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.896 0 Td [(con)40(v)15(erted)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -174.096 -11.955 Td [(into)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.992 0 Td [(something)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.005 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(WYSIWYG)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 51.736 0 Td [(w)10(ord)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.864 0 Td [(processor)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.667 0 Td [(can)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -174.096 -11.955 Td [(into)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.992 0 Td [(something)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.005 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(WYSIWYG)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 51.736 0 Td [(w)10(ord)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.864 0 Td [(processor)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.667 0 Td [(can)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -201.612 -11.955 Td [(read,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.127 0 Td [(b)20(ut)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.023 0 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -201.612 -11.955 Td [(read,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.127 0 Td [(b)20(ut)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.023 0 Td [(the)]TJ
 ET
 1 0 0 1 123.815 450.557 cm
 EMC
 /Span <</MCID 45>> BDC
 1 0 0 1 -123.815 -450.557 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 123.815 450.557 Td [(.pdf)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 123.815 450.557 Td [(.pdf)]TJ
 ET
 1 0 0 1 140.493 450.557 cm
 EMC
 /P <</MCID 46>> BDC
 1 0 0 1 -140.493 -450.557 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 142.983 450.557 Td [(output)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.955 0 Td [(from)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(L)]TJ/F79 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(needs)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.175 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(508-)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 142.983 450.557 Td [(output)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.955 0 Td [(from)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(L)]TJ/F80 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(needs)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.175 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(508-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -193.389 -11.955 Td [(compliant.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.429 0 Td [(As)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 13.559 0 Td [(508-compliance)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 66.679 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(often)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.964 0 Td [(judged)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.608 0 Td [(using)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -193.389 -11.955 Td [(compliant.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.429 0 Td [(As)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 13.559 0 Td [(508-compliance)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 66.679 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(often)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.964 0 Td [(judged)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.608 0 Td [(using)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -187.375 -11.955 Td [(automated)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 43.994 0 Td [(tests)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(on)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -187.375 -11.955 Td [(automated)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 43.994 0 Td [(tests)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(on)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(the)]TJ
 ET
 1 0 0 1 163.316 426.647 cm
 EMC
 /Span <</MCID 47>> BDC
 1 0 0 1 -163.316 -426.647 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 163.316 426.647 Td [(.pdf)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 163.316 426.647 Td [(.pdf)]TJ
 ET
 1 0 0 1 179.994 426.647 cm
 EMC
 /P <</MCID 48>> BDC
 1 0 0 1 -179.994 -426.647 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 182.484 426.647 Td [(\002le,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.714 0 Td [(there)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.405 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(no)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(option)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.955 0 Td [(to)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 182.484 426.647 Td [(\002le,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.714 0 Td [(there)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.405 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(no)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(option)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.955 0 Td [(to)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -200.147 -11.956 Td [(w)10(ork)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.864 0 Td [(around)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.157 0 Td [(this)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.886 0 Td [(by)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.454 0 Td [(using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.079 0 Td [(careful)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.147 0 Td [(te)15(xt)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.285 0 Td [(descriptions)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 50.639 0 Td [(of)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -200.147 -11.956 Td [(w)10(ork)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.864 0 Td [(around)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.157 0 Td [(this)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.886 0 Td [(by)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.454 0 Td [(using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.079 0 Td [(careful)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.147 0 Td [(te)15(xt)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.285 0 Td [(descriptions)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 50.639 0 Td [(of)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -204.511 -11.955 Td [(\002gures,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.099 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(e)15(xample.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -204.511 -11.955 Td [(\002gures,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.099 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(e)15(xample.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -2270,68 +2270,68 @@ EMC
 /P <</MCID 49>> BDC
 1 0 0 1 -72 -383.422 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 383.422 Td [(In)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(this)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.887 0 Td [(document,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.273 0 Td [(we)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(e)15(xplain)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.671 0 Td [(ho)25(w)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.398 0 Td [(L)]TJ/F79 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.241 Td [(E)]TJ 4.842 2.241 Td [(Xcan)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.512 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(used)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(in)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 383.422 Td [(In)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(this)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.887 0 Td [(document,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.273 0 Td [(we)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(e)15(xplain)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.671 0 Td [(ho)25(w)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.398 0 Td [(L)]TJ/F80 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.241 Td [(E)]TJ 4.842 2.241 Td [(Xcan)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.512 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(used)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(in)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -208.881 -11.955 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(corporate)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.109 0 Td [(en)40(vironment)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 52.453 0 Td [(where)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.829 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(re)25(vie)25(w)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.101 0 Td [(process)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.368 0 Td [(is)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -208.881 -11.955 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(corporate)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.109 0 Td [(en)40(vironment)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 52.453 0 Td [(where)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.829 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(re)25(vie)25(w)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.101 0 Td [(process)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.368 0 Td [(is)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -202.439 -11.955 Td [(centered)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.234 0 Td [(around)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.157 0 Td [(WYSIWYG)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 51.735 0 Td [(tools.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.956 0 Td [(T)80(o)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.762 0 Td [(do)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.454 0 Td [(this,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.377 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(custom)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -202.439 -11.955 Td [(centered)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.234 0 Td [(around)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.157 0 Td [(WYSIWYG)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 51.735 0 Td [(tools.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.956 0 Td [(T)80(o)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.762 0 Td [(do)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.454 0 Td [(this,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.377 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(custom)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -194.589 -11.955 Td [(class)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.222 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(used)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(generate)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.234 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(range)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.618 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(classes)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -194.589 -11.955 Td [(class)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.222 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(used)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(generate)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.234 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(range)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.618 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(classes)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -197.547 -11.955 Td [(with)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(common)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 37.36 0 Td [(formatting.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 47.64 0 Td [(The)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -197.547 -11.955 Td [(with)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(common)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 37.36 0 Td [(formatting.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 47.64 0 Td [(The)]TJ
 ET
 1 0 0 1 195.187 335.602 cm
 EMC
 /Span <</MCID 50>> BDC
 1 0 0 1 -195.187 -335.602 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 195.187 335.602 Td [(.te)20(x)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 195.187 335.602 Td [(.te)20(x)]TJ
 ET
 1 0 0 1 209.124 335.602 cm
 EMC
 /P <</MCID 51>> BDC
 1 0 0 1 -209.124 -335.602 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 211.615 335.602 Td [(\002les)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.098 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(con)40(v)15(erted)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 211.615 335.602 Td [(\002les)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.098 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(con)40(v)15(erted)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -186.927 -11.956 Td [(into)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.992 0 Td [(formats)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.926 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.318 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.896 0 Td [(shared)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.493 0 Td [(with)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(co)25(w)10(ork)10(ers)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 43.536 0 Td [(who)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.646 0 Td [(use)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -186.927 -11.956 Td [(into)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.992 0 Td [(formats)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.926 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.318 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.896 0 Td [(shared)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.493 0 Td [(with)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(co)25(w)10(ork)10(ers)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 43.536 0 Td [(who)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.646 0 Td [(use)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -208.446 -11.955 Td [(WYSIWYG)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 51.736 0 Td [(tools.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.956 0 Td [(W)80(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.521 0 Td [(e)15(xplain)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.671 0 Td [(ho)25(w)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.398 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(same)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.963 0 Td [(source)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.493 0 Td [(\002le)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -208.446 -11.955 Td [(WYSIWYG)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 51.736 0 Td [(tools.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.956 0 Td [(W)80(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.521 0 Td [(e)15(xplain)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.671 0 Td [(ho)25(w)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.398 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(same)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.963 0 Td [(source)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.493 0 Td [(\002le)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -209.403 -11.955 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(used)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(generate)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.233 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(508-compliant)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -209.403 -11.955 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(used)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(generate)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.233 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(508-compliant)]TJ
 ET
 1 0 0 1 234.957 299.736 cm
 EMC
 /Span <</MCID 52>> BDC
 1 0 0 1 -234.957 -299.736 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 234.957 299.736 Td [(*.pdf)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 234.957 299.736 Td [(*.pdf)]TJ
 ET
 1 0 0 1 256.616 299.736 cm
 EMC
 /P <</MCID 53>> BDC
 1 0 0 1 -256.616 -299.736 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 256.616 299.736 Td [(,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 4.981 0 Td [(direct)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 256.616 299.736 Td [(,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 4.981 0 Td [(direct)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -189.597 -11.955 Td [(from)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(L)]TJ/F79 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.772 0 Td [(W)80(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.522 0 Td [(also)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.54 0 Td [(sho)25(w)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.273 0 Td [(some)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.521 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(limitations)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.119 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -189.597 -11.955 Td [(from)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(L)]TJ/F80 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.772 0 Td [(W)80(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.522 0 Td [(also)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.54 0 Td [(sho)25(w)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.273 0 Td [(some)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.521 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(limitations)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.119 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(the)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -212.447 -11.955 Td [(method)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.378 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(what)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(remains)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.032 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.896 0 Td [(\002x)15(ed.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.354 0 Td [(Our)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.983 0 Td [(goal)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.646 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(that)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -212.447 -11.955 Td [(method)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.378 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(what)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(remains)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.032 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.896 0 Td [(\002x)15(ed.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.354 0 Td [(Our)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.983 0 Td [(goal)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.646 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(that)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -199.401 -11.955 Td [(this)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.886 0 Td [(will)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.993 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(`li)25(ving')]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.129 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(template)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.801 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(be)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -199.401 -11.955 Td [(this)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.886 0 Td [(will)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.993 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(`li)25(ving')]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.129 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(template)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.801 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(be)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -215.031 -11.956 Td [(updated)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.032 0 Td [(as)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(we)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(g)5(ain)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.596 0 Td [(ne)25(w)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.839 0 Td [(insight)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.619 0 Td [(into)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.992 0 Td [(this)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.886 0 Td [(process.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -215.031 -11.956 Td [(updated)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.032 0 Td [(as)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(we)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(g)5(ain)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.596 0 Td [(ne)25(w)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.839 0 Td [(insight)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.619 0 Td [(into)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.992 0 Td [(this)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.886 0 Td [(process.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -2342,7 +2342,7 @@ EMC
 /H <</MCID 54>> BDC
 1 0 0 1 -72 -212.931 cm
 BT
-/F81 11.9552 Tf/F82 1 Tf( )Tj/F81 11.9552 Tf 72 212.931 Td [(2)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 18.602 0 Td [(Requirements)]TJ
+/F83 11.9552 Tf/F84 1 Tf( )Tj/F83 11.9552 Tf 72 212.931 Td [(2)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 18.602 0 Td [(Requirements)]TJ
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 g 0 G
@@ -2353,10 +2353,10 @@ EMC
 /P <</MCID 55>> BDC
 1 0 0 1 -72 -191.875 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 191.875 Td [(The)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.982 0 Td [(requirements)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 54.505 0 Td [(identi\002ed)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.129 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(introduction)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 51.197 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(be)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 191.875 Td [(The)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.982 0 Td [(requirements)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 54.505 0 Td [(identi\002ed)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.129 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(introduction)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 51.197 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(be)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -205.039 -11.956 Td [(summarized)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 51.187 0 Td [(as)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(follo)25(ws:)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -205.039 -11.956 Td [(summarized)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 51.187 0 Td [(as)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(follo)25(ws:)]TJ
 ET
 1 0 0 1 169.473 179.919 cm
 EMC
@@ -2367,7 +2367,7 @@ EMC
 /Lbl <</MCID 56>> BDC
 1 0 0 1 -80.966 -160.605 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 83.457 160.605 Td [(\225)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 83.457 160.605 Td [(\225)]TJ
 ET
 1 0 0 1 86.944 160.605 cm
 EMC
@@ -2376,13 +2376,13 @@ EMC
 /LBody <</MCID 57>> BDC
 1 0 0 1 -91.925 -160.605 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 91.925 160.605 Td [(A)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(single)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.291 0 Td [(L)]TJ/F79 7.3723 Tf 2.501 1.488 Td [(A)]TJ/F79 9.9626 Tf 3.828 -1.488 Td [(T)]TJ 4.426 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(class)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.857 0 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(ensures)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.368 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(an)15(y)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 91.925 160.605 Td [(A)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(single)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.291 0 Td [(L)]TJ/F80 7.3723 Tf 2.501 1.488 Td [(A)]TJ/F80 9.9626 Tf 3.828 -1.488 Td [(T)]TJ 4.426 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(class)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.857 0 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(ensures)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.368 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(an)15(y)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -165.573 -11.955 Td [(written)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.715 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(produced)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.561 0 Td [(using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.08 0 Td [(L)]TJ/F79 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(conforms)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -165.573 -11.955 Td [(written)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.715 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(produced)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.561 0 Td [(using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.08 0 Td [(L)]TJ/F80 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(conforms)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -161.42 -11.955 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(corporate)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.109 0 Td [(brand)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -161.42 -11.955 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(corporate)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.109 0 Td [(brand)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -2392,7 +2392,7 @@ EMC
 /Lbl <</MCID 58>> BDC
 1 0 0 1 -80.966 -117.381 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 83.457 117.381 Td [(\225)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 83.457 117.381 Td [(\225)]TJ
 ET
 1 0 0 1 86.944 117.381 cm
 EMC
@@ -2401,10 +2401,10 @@ EMC
 /LBody <</MCID 59>> BDC
 1 0 0 1 -91.925 -117.381 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 91.925 117.381 Td [(The)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.983 0 Td [(te)15(x)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.515 0 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(con)40(v)15(erted)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.225 0 Td [(into)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.993 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(format)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.05 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(can)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 91.925 117.381 Td [(The)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.983 0 Td [(te)15(x)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.515 0 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(con)40(v)15(erted)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.225 0 Td [(into)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.993 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(format)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.05 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(can)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -188.552 -11.955 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.896 0 Td [(read)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.636 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(edited)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.839 0 Td [(by)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(WYSIWYG)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 51.736 0 Td [(tool)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -188.552 -11.955 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.896 0 Td [(read)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.636 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(edited)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.839 0 Td [(by)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(WYSIWYG)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 51.736 0 Td [(tool)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -2414,7 +2414,7 @@ EMC
 /Lbl <</MCID 60>> BDC
 1 0 0 1 -80.966 -86.112 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 83.457 86.112 Td [(\225)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 83.457 86.112 Td [(\225)]TJ
 ET
 1 0 0 1 86.944 86.112 cm
 EMC
@@ -2423,10 +2423,10 @@ EMC
 /LBody <</MCID 61>> BDC
 1 0 0 1 -91.925 -86.112 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 91.925 86.112 Td [(The)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.983 0 Td [(PDF)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.762 0 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.222 0 Td [(produced)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.562 0 Td [(from)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(L)]TJ/F79 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(should)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.061 0 Td [(passes)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 91.925 86.112 Td [(The)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.983 0 Td [(PDF)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.762 0 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.222 0 Td [(produced)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.562 0 Td [(from)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(L)]TJ/F80 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(should)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.061 0 Td [(passes)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -169.729 -11.955 Td [(automated)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 43.995 0 Td [(accessibility)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 51.745 0 Td [(tests)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(Adobe)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.051 0 Td [(Acrobat)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -169.729 -11.955 Td [(automated)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 43.995 0 Td [(accessibility)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 51.745 0 Td [(tests)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(Adobe)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.051 0 Td [(Acrobat)]TJ
 0 g 0 G
 ET
 1 0 0 1 72 74.157 cm
@@ -2439,10 +2439,10 @@ EMC
 /H <</MCID 62>> BDC
 1 0 0 1 -310.981 -674.037 cm
 BT
-/F81 11.9552 Tf/F82 1 Tf( )Tj/F81 11.9552 Tf 310.981 674.037 Td [(3)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 18.602 0 Td [(A)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 11.955 0 Td [(w)20(ork\003o)15(w)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 54.719 0 Td [(f)20(or)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 19.02 0 Td [(pr)20(oducing)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 61.533 0 Td [(accessib)10(le)]TJ
+/F83 11.9552 Tf/F84 1 Tf( )Tj/F83 11.9552 Tf 310.981 674.037 Td [(3)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 18.602 0 Td [(A)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 11.955 0 Td [(w)20(ork\003o)15(w)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 54.719 0 Td [(f)20(or)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 19.02 0 Td [(pr)20(oducing)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 61.533 0 Td [(accessib)10(le)]TJ
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
-/F82 1 Tf( )Tj/F81 11.9552 Tf -147.227 -13.947 Td [(.pdf)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 25.237 0 Td [(\002les)]TJ
+/F84 1 Tf( )Tj/F83 11.9552 Tf -147.227 -13.947 Td [(.pdf)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 25.237 0 Td [(\002les)]TJ
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 g 0 G
@@ -2453,10 +2453,10 @@ EMC
 /P <</MCID 63>> BDC
 1 0 0 1 -310.981 -640.73 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 640.73 Td [(The)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.983 0 Td [(follo)25(wing)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.986 0 Td [(w)10(ork\003o)25(w)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.328 0 Td [(satis\002es)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.042 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(requirements)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 54.505 0 Td [(set)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 13.559 0 Td [(out)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 640.73 Td [(The)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.983 0 Td [(follo)25(wing)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.986 0 Td [(w)10(ork\003o)25(w)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.328 0 Td [(satis\002es)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.042 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(requirements)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 54.505 0 Td [(set)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 13.559 0 Td [(out)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -216.068 -11.955 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(pre)25(vious)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.552 0 Td [(section:)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -216.068 -11.955 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(pre)25(vious)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.552 0 Td [(section:)]TJ
 ET
 1 0 0 1 406.522 628.775 cm
 EMC
@@ -2467,7 +2467,7 @@ EMC
 /Lbl <</MCID 64>> BDC
 1 0 0 1 -315.963 -610.631 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 318.453 610.631 Td [(1.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 318.453 610.631 Td [(1.)]TJ
 ET
 1 0 0 1 325.925 610.631 cm
 EMC
@@ -2476,36 +2476,36 @@ EMC
 /LBody <</MCID 65>> BDC
 1 0 0 1 -330.907 -610.631 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 330.907 610.631 Td [(De\002ne)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.05 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.915 0 Td [(class)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.857 0 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(contains)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.696 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(correct)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.146 0 Td [(for)20(-)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 330.907 610.631 Td [(De\002ne)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.05 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.915 0 Td [(class)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.857 0 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(contains)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.696 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(correct)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.146 0 Td [(for)20(-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -170.986 -11.955 Td [(matting,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.426 0 Td [(etc,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.598 0 Td [(using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.079 0 Td [(article,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.878 0 Td [(report)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.281 0 Td [(or)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(book)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.416 0 Td [(classes.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -170.986 -11.955 Td [(matting,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.426 0 Td [(etc,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.598 0 Td [(using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.079 0 Td [(article,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.878 0 Td [(report)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.281 0 Td [(or)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(book)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.416 0 Td [(classes.)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -165.467 -11.955 Td [(Include)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.368 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(minimum)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.245 0 Td [(number)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.926 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(up-to-date)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 43.437 0 Td [(pack-)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -165.467 -11.955 Td [(Include)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.368 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(minimum)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.245 0 Td [(number)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.926 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(up-to-date)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 43.437 0 Td [(pack-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -175.43 -11.955 Td [(ages)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.194 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(class)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(add)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -175.43 -11.955 Td [(ages)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.194 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(class)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(add)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(the)]TJ
 ET
 1 0 0 1 446.283 574.766 cm
 EMC
 /Span <</MCID 66>> BDC
 1 0 0 1 -446.283 -574.766 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 446.283 574.766 Td [(nag)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 446.283 574.766 Td [(nag)]TJ
 ET
 1 0 0 1 461.785 574.766 cm
 EMC
 /LBody <</MCID 67>> BDC
 1 0 0 1 -461.785 -574.766 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 464.275 574.766 Td [(package)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.128 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(mak)10(e)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 464.275 574.766 Td [(package)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.128 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(mak)10(e)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -178.738 -11.955 Td [(sure)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.088 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(all)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(users)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.964 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.318 0 Td [(see)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.213 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(those)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.521 0 Td [(packages)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.003 0 Td [(are)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -178.738 -11.955 Td [(sure)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.088 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(all)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(users)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.964 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.318 0 Td [(see)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.213 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(those)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.521 0 Td [(packages)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.003 0 Td [(are)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -183.429 -11.956 Td [(not)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.222 0 Td [(deprecated.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -183.429 -11.956 Td [(not)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.222 0 Td [(deprecated.)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -2515,7 +2515,7 @@ EMC
 /Lbl <</MCID 68>> BDC
 1 0 0 1 -315.963 -532.712 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 318.453 532.712 Td [(2.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 318.453 532.712 Td [(2.)]TJ
 ET
 1 0 0 1 325.925 532.712 cm
 EMC
@@ -2524,14 +2524,14 @@ EMC
 /LBody <</MCID 69>> BDC
 1 0 0 1 -330.907 -532.712 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 330.907 532.712 Td [(Pro)15(vide)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 33.334 0 Td [(tools)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.868 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(add)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(accessibility)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 51.745 0 Td [(support)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.379 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(the)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 330.907 532.712 Td [(Pro)15(vide)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 33.334 0 Td [(tools)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.868 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(add)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(accessibility)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 51.745 0 Td [(support)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.379 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(the)]TJ
 ET
 1 0 0 1 522.257 532.712 cm
 EMC
 /Span <</MCID 70>> BDC
 1 0 0 1 -522.257 -532.712 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 522.257 532.712 Td [(.pdf)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 522.257 532.712 Td [(.pdf)]TJ
 ET
 1 0 0 1 538.934 532.712 cm
 EMC
@@ -2540,7 +2540,7 @@ EMC
 0 g 0 G
 1 0 0 1 -538.934 -532.712 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 330.907 520.757 Td [(\002le)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 330.907 520.757 Td [(\002le)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -2550,7 +2550,7 @@ EMC
 /Lbl <</MCID 72>> BDC
 1 0 0 1 -315.963 -502.613 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 318.453 502.613 Td [(3.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 318.453 502.613 Td [(3.)]TJ
 ET
 1 0 0 1 325.925 502.613 cm
 EMC
@@ -2559,7 +2559,7 @@ EMC
 /LBody <</MCID 73>> BDC
 1 0 0 1 -330.907 -502.613 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 330.907 502.613 Td [(Create)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.492 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(template)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.802 0 Td [(sho)25(wing)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.005 0 Td [(ho)25(w)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.397 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(use)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.771 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(class)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.857 0 Td [(\002le)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 330.907 502.613 Td [(Create)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.492 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(template)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.802 0 Td [(sho)25(wing)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.005 0 Td [(ho)25(w)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.397 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(use)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.771 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(class)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.857 0 Td [(\002le)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -2569,7 +2569,7 @@ EMC
 /Lbl <</MCID 74>> BDC
 1 0 0 1 -315.963 -484.469 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 318.453 484.469 Td [(4.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 318.453 484.469 Td [(4.)]TJ
 ET
 1 0 0 1 325.925 484.469 cm
 EMC
@@ -2578,13 +2578,13 @@ EMC
 /LBody <</MCID 75>> BDC
 1 0 0 1 -330.907 -484.469 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 330.907 484.469 Td [(Create)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.492 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(source)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.493 0 Td [(code)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(repository)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 42.889 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(class)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.857 0 Td [(and)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 330.907 484.469 Td [(Create)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.492 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(source)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.493 0 Td [(code)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(repository)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 42.889 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(class)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.857 0 Td [(and)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -178.717 -11.955 Td [(template)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.801 0 Td [(\002les,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.589 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(distrib)20(ute)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.93 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(URL)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.416 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(reposi-)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -178.717 -11.955 Td [(template)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.801 0 Td [(\002les,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.589 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(distrib)20(ute)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.93 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(URL)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.416 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(reposi-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -177.731 -11.955 Td [(tory)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.54 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(LaT)70(eX)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.008 0 Td [(users)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -177.731 -11.955 Td [(tory)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.54 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(LaT)70(eX)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.008 0 Td [(users)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -2594,7 +2594,7 @@ EMC
 /Lbl <</MCID 76>> BDC
 1 0 0 1 -315.963 -442.415 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 318.453 442.415 Td [(5.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 318.453 442.415 Td [(5.)]TJ
 ET
 1 0 0 1 325.925 442.415 cm
 EMC
@@ -2603,13 +2603,13 @@ EMC
 /LBody <</MCID 77>> BDC
 1 0 0 1 -330.907 -442.415 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 330.907 442.415 Td [(Create)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.492 0 Td [(documents)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.659 0 Td [(using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.079 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(standard)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.244 0 Td [(class)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.857 0 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(on)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 330.907 442.415 Td [(Create)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.492 0 Td [(documents)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.659 0 Td [(using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.079 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(standard)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.244 0 Td [(class)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.857 0 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(on)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -186.219 -11.955 Td [(local)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.857 0 Td [(or)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(netw)10(ork)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.038 0 Td [(dri)25(v)15(es,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.932 0 Td [(or)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.079 0 Td [(collaborati)25(v)15(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 54.107 0 Td [(tools)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -186.219 -11.955 Td [(local)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.857 0 Td [(or)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(netw)10(ork)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.038 0 Td [(dri)25(v)15(es,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.932 0 Td [(or)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.079 0 Td [(collaborati)25(v)15(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 54.107 0 Td [(tools)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -185.592 -11.955 Td [(lik)10(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.334 0 Td [(writeLaT)70(eX)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -185.592 -11.955 Td [(lik)10(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.334 0 Td [(writeLaT)70(eX)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -2619,7 +2619,7 @@ EMC
 /Lbl <</MCID 78>> BDC
 1 0 0 1 -315.963 -400.361 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 318.453 400.361 Td [(6.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 318.453 400.361 Td [(6.)]TJ
 ET
 1 0 0 1 325.925 400.361 cm
 EMC
@@ -2628,10 +2628,10 @@ EMC
 /LBody <</MCID 79>> BDC
 1 0 0 1 -330.907 -400.361 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 330.907 400.361 Td [(Con)40(v)15(ert)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.042 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(te)15(x)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.515 0 Td [(\002les)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.098 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(rtf)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.079 0 Td [(LaT)70(eX2rtf,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 46.884 0 Td [(a)20(v)25(ail-)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 330.907 400.361 Td [(Con)40(v)15(ert)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.042 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(te)15(x)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.515 0 Td [(\002les)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.098 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(rtf)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.079 0 Td [(LaT)70(eX2rtf,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 46.884 0 Td [(a)20(v)25(ail-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -175.42 -11.955 Td [(able)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.088 0 Td [(at)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.683 0 Td [(http://late)15(x2rtf.sourcefor)18(ge.net)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -175.42 -11.955 Td [(able)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.088 0 Td [(at)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.683 0 Td [(http://late)15(x2rtf.sourcefor)18(ge.net)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -2641,7 +2641,7 @@ EMC
 /Lbl <</MCID 80>> BDC
 1 0 0 1 -315.963 -370.262 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 318.453 370.262 Td [(7.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 318.453 370.262 Td [(7.)]TJ
 ET
 1 0 0 1 325.925 370.262 cm
 EMC
@@ -2650,10 +2650,10 @@ EMC
 /LBody <</MCID 81>> BDC
 1 0 0 1 -330.907 -370.262 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 330.907 370.262 Td [(Get)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(edits)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.31 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(peer)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.636 0 Td [(re)25(vie)25(ws)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.976 0 Td [(done)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(on)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(cleaned-up)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 46.196 0 Td [(.rtf)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 330.907 370.262 Td [(Get)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(edits)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.31 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(peer)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.636 0 Td [(re)25(vie)25(ws)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.976 0 Td [(done)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(on)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(cleaned-up)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 46.196 0 Td [(.rtf)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -195.096 -11.955 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.222 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(has)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.77 0 Td [(been)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(sa)20(v)15(ed)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.827 0 Td [(as)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(.doc)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.367 0 Td [(or)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(.docx)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -195.096 -11.955 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.222 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(has)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.77 0 Td [(been)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(sa)20(v)15(ed)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.827 0 Td [(as)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(.doc)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.367 0 Td [(or)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(.docx)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -2663,7 +2663,7 @@ EMC
 /Lbl <</MCID 82>> BDC
 1 0 0 1 -315.963 -340.163 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 318.453 340.163 Td [(8.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 318.453 340.163 Td [(8.)]TJ
 ET
 1 0 0 1 325.925 340.163 cm
 EMC
@@ -2672,13 +2672,13 @@ EMC
 /LBody <</MCID 83>> BDC
 1 0 0 1 -330.907 -340.163 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 330.907 340.163 Td [(T)35(ransfer)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.885 0 Td [(edits)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.309 0 Td [(from)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(.doc)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.367 0 Td [(or)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(.docx)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.349 0 Td [(document)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 330.907 340.163 Td [(T)35(ransfer)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.885 0 Td [(edits)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.309 0 Td [(from)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(.doc)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.367 0 Td [(or)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(.docx)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.349 0 Td [(document)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -148.223 -11.955 Td [(back)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(')18(te)15(x)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.653 0 Td [(manually)65(,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.415 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(complete)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.014 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.664 0 Td [(PDF)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -148.223 -11.955 Td [(back)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(')18(te)15(x)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.653 0 Td [(manually)65(,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.415 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(complete)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.014 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.664 0 Td [(PDF)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -171.405 -11.955 Td [(production)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.658 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(LaT)70(eX.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -171.405 -11.955 Td [(production)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.658 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(LaT)70(eX.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -2688,10 +2688,10 @@ EMC
 /P <</MCID 84>> BDC
 1 0 0 1 -310.981 -298.109 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 298.109 Td [(The)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.983 0 Td [(rest)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(this)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.886 0 Td [(section)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.714 0 Td [(gi)25(v)15(es)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.124 0 Td [(details)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.502 0 Td [(on)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(each)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.742 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(abo)15(v)15(e)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 298.109 Td [(The)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.983 0 Td [(rest)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(this)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.886 0 Td [(section)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.714 0 Td [(gi)25(v)15(es)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.124 0 Td [(details)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.502 0 Td [(on)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(each)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.742 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(abo)15(v)15(e)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -203.525 -11.955 Td [(steps.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -203.525 -11.955 Td [(steps.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -2700,19 +2700,19 @@ EMC
 /P <</MCID 85>> BDC
 1 0 0 1 -310.981 -268.01 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 268.01 Td [(N.B.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.31 0 Td [(Collaborati)25(v)15(e,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 58.819 0 Td [(web-based)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.091 0 Td [(tools)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.867 0 Td [(ha)20(v)15(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.952 0 Td [(recently)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 268.01 Td [(N.B.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.31 0 Td [(Collaborati)25(v)15(e,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 58.819 0 Td [(web-based)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.091 0 Td [(tools)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.867 0 Td [(ha)20(v)15(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.952 0 Td [(recently)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -168.039 -11.955 Td [(\050March)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.811 0 Td [(2017\051)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.733 0 Td [(started)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.051 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(implement)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.11 0 Td [(corporate)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.11 0 Td [(templates)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -168.039 -11.955 Td [(\050March)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.811 0 Td [(2017\051)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.733 0 Td [(started)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.051 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(implement)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.11 0 Td [(corporate)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.11 0 Td [(templates)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -182.056 -11.955 Td [(with)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(will)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.992 0 Td [(help)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.647 0 Td [(with)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(item)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.203 0 Td [(4)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(5.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.56 0 Td [(Some)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.186 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(these)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.964 0 Td [(tools)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -182.056 -11.955 Td [(with)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(will)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.992 0 Td [(help)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.647 0 Td [(with)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(item)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.203 0 Td [(4)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(5.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.56 0 Td [(Some)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.186 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(these)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.964 0 Td [(tools)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -192.098 -11.955 Td [(also)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.54 0 Td [(include)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.821 0 Td [(\223track)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.829 0 Td [(changes\224)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.003 0 Td [(functionality)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 53.409 0 Td [(which)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.839 0 Td [(can)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -192.098 -11.955 Td [(also)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.54 0 Td [(include)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.821 0 Td [(\223track)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.829 0 Td [(changes\224)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.003 0 Td [(functionality)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 53.409 0 Td [(which)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.839 0 Td [(can)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -196.441 -11.956 Td [(remo)15(v)15(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.07 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(need)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(steps)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.415 0 Td [(6-8.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -196.441 -11.956 Td [(remo)15(v)15(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.07 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(need)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(steps)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.415 0 Td [(6-8.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -2723,7 +2723,7 @@ EMC
 /H <</MCID 86>> BDC
 1 0 0 1 -310.981 -187.001 cm
 BT
-/F92 9.9626 Tf/F82 1 Tf( )Tj/F92 9.9626 Tf 310.981 187.001 Td [(3.1)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 23.811 0 Td [(A)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 9.962 0 Td [(\223meta\224)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 35.985 0 Td [(LaT)60(eX)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 32.069 0 Td [(style)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 25.474 0 Td [(\002le)]TJ
+/F94 9.9626 Tf/F84 1 Tf( )Tj/F94 9.9626 Tf 310.981 187.001 Td [(3.1)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 23.811 0 Td [(A)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 9.962 0 Td [(\223meta\224)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 35.985 0 Td [(LaT)60(eX)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 32.069 0 Td [(style)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 25.474 0 Td [(\002le)]TJ
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 g 0 G
@@ -2734,33 +2734,33 @@ EMC
 /P <</MCID 87>> BDC
 1 0 0 1 -310.981 -167.641 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 167.641 Td [(A)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(class)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.222 0 Td [(called)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 167.641 Td [(A)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(class)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.222 0 Td [(called)]TJ
 ET
 1 0 0 1 384.026 167.641 cm
 EMC
 /Span <</MCID 88>> BDC
 1 0 0 1 -384.026 -167.641 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 384.026 167.641 Td [(meta.cls)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 384.026 167.641 Td [(meta.cls)]TJ
 ET
 1 0 0 1 416.952 167.641 cm
 EMC
 /P <</MCID 89>> BDC
 1 0 0 1 -416.952 -167.641 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 419.443 167.641 Td [(has)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.771 0 Td [(been)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(written)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.714 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(imple-)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 419.443 167.641 Td [(has)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.771 0 Td [(been)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(written)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.714 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(imple-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -186.489 -11.955 Td [(ment)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.416 0 Td [(common)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 37.36 0 Td [(formatting)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.552 0 Td [(requirements)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 54.505 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(L)]TJ/F79 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.427 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.683 0 Td [(across)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -186.489 -11.955 Td [(ment)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.416 0 Td [(common)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 37.36 0 Td [(formatting)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.552 0 Td [(requirements)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 54.505 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(L)]TJ/F80 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.427 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.683 0 Td [(across)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -194.355 -11.955 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(standard)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.244 0 Td [(L)]TJ/F79 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(article,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.877 0 Td [(report,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.772 0 Td [(book,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.907 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(memoir)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -194.355 -11.955 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(standard)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.244 0 Td [(L)]TJ/F80 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(article,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.877 0 Td [(report,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.772 0 Td [(book,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.907 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(memoir)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -176.622 -11.955 Td [(classes.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 33.245 0 Td [(The)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.983 0 Td [(class)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.857 0 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(calls)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(common)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 37.359 0 Td [(group)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.734 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(pack-)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -176.622 -11.955 Td [(classes.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 33.245 0 Td [(The)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.983 0 Td [(class)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.857 0 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(calls)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(common)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 37.359 0 Td [(group)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.734 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(pack-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -189.856 -11.955 Td [(ages)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.194 0 Td [(\050T)80(able)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -189.856 -11.955 Td [(ages)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.194 0 Td [(\050T)80(able)]TJ
 ET
 1 0 0 1 358.871 119.821 cm
 EMC
@@ -2768,7 +2768,7 @@ EMC
 0 g 0 G
 1 0 0 1 -358.871 -119.821 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 358.871 119.821 Td [(1)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 358.871 119.821 Td [(1)]TJ
 0 g 0 G
 ET
 1 0 0 1 363.853 119.821 cm
@@ -2776,19 +2776,19 @@ EMC
 /P <</MCID 91>> BDC
 1 0 0 1 -363.853 -119.821 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 363.853 119.821 Td [(\051)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 5.808 0 Td [(re)15(g)5(ardless)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 42.679 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(chosen)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.156 0 Td [(class.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.946 0 Td [(Slightly)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 363.853 119.821 Td [(\051)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 5.808 0 Td [(re)15(g)5(ardless)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 42.679 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(chosen)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.156 0 Td [(class.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.946 0 Td [(Slightly)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -181.916 -11.956 Td [(dif)25(ferent)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.543 0 Td [(options)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.83 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(chosen)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.157 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(those)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.521 0 Td [(packages)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.004 0 Td [(if)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 8.577 0 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -181.916 -11.956 Td [(dif)25(ferent)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.543 0 Td [(options)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.83 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(chosen)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.157 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(those)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.521 0 Td [(packages)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.004 0 Td [(if)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 8.577 0 Td [(the)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -198.394 -11.955 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(uses)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.646 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(memoir)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 33.484 0 Td [(class,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.348 0 Td [(or)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(if)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 8.578 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.664 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(uses)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -198.394 -11.955 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(uses)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.646 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(memoir)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 33.484 0 Td [(class,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.348 0 Td [(or)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(if)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 8.578 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.664 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(uses)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -209.741 -11.955 Td [(chapters)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.686 0 Td [(or)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(not.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.311 0 Td [(The)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.982 0 Td [(class)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(customized)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 47.87 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(meet)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -209.741 -11.955 Td [(chapters)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.686 0 Td [(or)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(not.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.311 0 Td [(The)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.982 0 Td [(class)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(customized)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 47.87 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(meet)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -190.952 -11.955 Td [(speci\002c)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.926 0 Td [(formatting)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.553 0 Td [(requirements.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -190.952 -11.955 Td [(speci\002c)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.926 0 Td [(formatting)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.553 0 Td [(requirements.)]TJ
 0 g 0 G
 ET
 1 0 0 1 310.981 72 cm
@@ -2799,7 +2799,7 @@ EMC
 /Artifact <</Type /Pagination>> BDC
 1 0 0 1 -72 -42.112 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 303.509 42.112 Td [(2)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 303.509 42.112 Td [(2)]TJ
 ET
 1 0 0 1 540 42.112 cm
 EMC
@@ -2807,17 +2807,17 @@ EMC
 
 endstream
 endobj
-155 0 obj
+157 0 obj
 <<
 /Type /Page
-/Contents 232 0 R
-/Resources 231 0 R
+/Contents 234 0 R
+/Resources 233 0 R
 /MediaBox [0 0 612 792]
-/Parent 152 0 R
-/Annots [ 228 0 R ]
+/Parent 154 0 R
+/Annots [ 230 0 R ]
 >>
 endobj
-228 0 obj
+230 0 obj
 <<
 /Type /Annot
 /Subtype /Link
@@ -2826,497 +2826,497 @@ endobj
 /A << /S /GoTo /D (table.caption.2) >>
 >>
 endobj
-233 0 obj
+235 0 obj
 <<
-/D [155 0 R /XYZ 71 718.907 null]
+/D [157 0 R /XYZ 71 718.907 null]
 >>
 endobj
 11 0 obj
 <<
-/D [155 0 R /XYZ 72 232.081 null]
+/D [157 0 R /XYZ 72 232.081 null]
 >>
 endobj
 15 0 obj
 <<
-/D [155 0 R /XYZ 310.981 684 null]
->>
-endobj
-234 0 obj
-<<
-/D [155 0 R /XYZ 310.981 626.618 null]
+/D [157 0 R /XYZ 310.981 684 null]
 >>
 endobj
 236 0 obj
 <<
-/D [155 0 R /XYZ 310.981 548.699 null]
->>
-endobj
-237 0 obj
-<<
-/D [155 0 R /XYZ 310.981 520.657 null]
+/D [157 0 R /XYZ 310.981 626.618 null]
 >>
 endobj
 238 0 obj
 <<
-/D [155 0 R /XYZ 310.981 500.456 null]
+/D [157 0 R /XYZ 310.981 548.699 null]
 >>
 endobj
 239 0 obj
 <<
-/D [155 0 R /XYZ 310.981 458.402 null]
+/D [157 0 R /XYZ 310.981 520.657 null]
 >>
 endobj
 240 0 obj
 <<
-/D [155 0 R /XYZ 310.981 418.405 null]
+/D [157 0 R /XYZ 310.981 500.456 null]
 >>
 endobj
 241 0 obj
 <<
-/D [155 0 R /XYZ 310.981 386.249 null]
+/D [157 0 R /XYZ 310.981 458.402 null]
 >>
 endobj
 242 0 obj
 <<
-/D [155 0 R /XYZ 310.981 358.207 null]
+/D [157 0 R /XYZ 310.981 418.405 null]
+>>
+endobj
+243 0 obj
+<<
+/D [157 0 R /XYZ 310.981 386.249 null]
+>>
+endobj
+244 0 obj
+<<
+/D [157 0 R /XYZ 310.981 358.207 null]
 >>
 endobj
 19 0 obj
 <<
-/D [155 0 R /XYZ 310.981 202.988 null]
+/D [157 0 R /XYZ 310.981 202.988 null]
 >>
 endobj
-231 0 obj
+233 0 obj
 <<
  /ColorSpace 3 0 R /Pattern 2 0 R /ExtGState 1 0 R 
-/Font << /F79 141 0 R /F82 145 0 R /F85 146 0 R /F81 144 0 R /F91 235 0 R /F92 243 0 R >>
+/Font << /F80 143 0 R /F84 147 0 R /F87 148 0 R /F83 146 0 R /F93 237 0 R /F94 245 0 R >>
 /ProcSet [ /PDF /Text ]
 >>
 endobj
-229 0 obj
-<</Type /StructElem /P 223 0 R /K [ <</Type /MCR /Pg 155  0 R /MCID 92>> 230 0 R <</Type /MCR /Pg 155  0 R /MCID 94>>] /S /P /Lang(EN)>>
-endobj
-246 0 obj
-<</Type /StructElem /P 244 0 R /K <</Type /MCR /Pg 245  0 R /MCID 96>> /S /Span  /Lang(EN)  >>
-endobj
-247 0 obj
-<</Type /StructElem /P 244 0 R /K <</Type /MCR /Pg 245  0 R /MCID 98>> /S /Code  /Lang(EN)  >>
-endobj
-244 0 obj
-<</Type /StructElem /P 223 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 95>> 246 0 R <</Type /MCR /Pg 245  0 R /MCID 97>> 247 0 R <</Type /MCR /Pg 245  0 R /MCID 99>>] /S /P /Lang(EN)>>
+231 0 obj
+<</Type /StructElem /P 225 0 R /K [ <</Type /MCR /Pg 157  0 R /MCID 92>> 232 0 R <</Type /MCR /Pg 157  0 R /MCID 94>>] /S /P /Lang(EN)>>
 endobj
 248 0 obj
-<</Type /StructElem /P 223 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 100>>] /S /P /Lang(EN)>>
-endobj
-251 0 obj
-<</Type /StructElem /P 250 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 101>>] /S /Lbl /Lang(EN)  >>
-endobj
-253 0 obj
-<</Type /StructElem /P 252 0 R /K <</Type /MCR /Pg 245  0 R /MCID 103>> /S /Span  /Lang(EN)  >>
-endobj
-252 0 obj
-<</Type /StructElem /P 250 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 102>> 253 0 R <</Type /MCR /Pg 245  0 R /MCID 104>>] /S /LBody /Lang(EN)  >>
-endobj
-250 0 obj
-<</Type /StructElem /P 249 0 R  /Lang(EN)/K [ 251 0 R 252 0 R] /S /LI>>
-endobj
-255 0 obj
-<</Type /StructElem /P 254 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 105>>] /S /Lbl /Lang(EN)  >>
-endobj
-257 0 obj
-<</Type /StructElem /P 256 0 R /K <</Type /MCR /Pg 245  0 R /MCID 107>> /S /Span  /Lang(EN)  >>
-endobj
-256 0 obj
-<</Type /StructElem /P 254 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 106>> 257 0 R <</Type /MCR /Pg 245  0 R /MCID 108>>] /S /LBody /Lang(EN)  >>
-endobj
-254 0 obj
-<</Type /StructElem /P 249 0 R  /Lang(EN)/K [ 255 0 R 256 0 R] /S /LI>>
-endobj
-259 0 obj
-<</Type /StructElem /P 258 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 109>>] /S /Lbl /Lang(EN)  >>
-endobj
-261 0 obj
-<</Type /StructElem /P 260 0 R /K <</Type /MCR /Pg 245  0 R /MCID 111>> /S /Span  /Lang(EN)  >>
-endobj
-260 0 obj
-<</Type /StructElem /P 258 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 110>> 261 0 R <</Type /MCR /Pg 245  0 R /MCID 112>>] /S /LBody /Lang(EN)  >>
-endobj
-258 0 obj
-<</Type /StructElem /P 249 0 R  /Lang(EN)/K [ 259 0 R 260 0 R] /S /LI>>
-endobj
-263 0 obj
-<</Type /StructElem /P 262 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 113>>] /S /Lbl /Lang(EN)  >>
-endobj
-265 0 obj
-<</Type /StructElem /P 264 0 R /K <</Type /MCR /Pg 245  0 R /MCID 115>> /S /Span  /Lang(EN)  >>
-endobj
-264 0 obj
-<</Type /StructElem /P 262 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 114>> 265 0 R <</Type /MCR /Pg 245  0 R /MCID 116>>] /S /LBody /Lang(EN)  >>
-endobj
-262 0 obj
-<</Type /StructElem /P 249 0 R  /Lang(EN)/K [ 263 0 R 264 0 R] /S /LI>>
-endobj
-267 0 obj
-<</Type /StructElem /P 266 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 117>>] /S /Lbl /Lang(EN)  >>
-endobj
-268 0 obj
-<</Type /StructElem /P 266 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 118>>] /S /LBody /Lang(EN)  >>
-endobj
-266 0 obj
-<</Type /StructElem /P 249 0 R  /Lang(EN)/K [ 267 0 R 268 0 R] /S /LI>>
-endobj
-270 0 obj
-<</Type /StructElem /P 269 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 119>>] /S /Lbl /Lang(EN)  >>
-endobj
-271 0 obj
-<</Type /StructElem /P 269 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 120>>] /S /LBody /Lang(EN)  >>
-endobj
-269 0 obj
-<</Type /StructElem /P 249 0 R  /Lang(EN)/K [ 270 0 R 271 0 R] /S /LI>>
-endobj
-273 0 obj
-<</Type /StructElem /P 272 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 121>>] /S /Lbl /Lang(EN)  >>
-endobj
-274 0 obj
-<</Type /StructElem /P 272 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 122>>] /S /LBody /Lang(EN)  >>
-endobj
-272 0 obj
-<</Type /StructElem /P 249 0 R  /Lang(EN)/K [ 273 0 R 274 0 R] /S /LI>>
+<</Type /StructElem /P 246 0 R /K <</Type /MCR /Pg 247  0 R /MCID 96>> /S /Span  /Lang(EN)  >>
 endobj
 249 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 250 0 R 254 0 R 258 0 R 262 0 R 266 0 R 269 0 R 272 0 R] /S /L1>>
+<</Type /StructElem /P 246 0 R /K <</Type /MCR /Pg 247  0 R /MCID 98>> /S /Code  /Lang(EN)  >>
 endobj
-276 0 obj
-<</Type /StructElem /P 275 0 R /K [<</Type /MCR /Pg 245  0 R /MCID 124>> <</Type /OBJR /Obj 277 0 R>>] /S /Reference>>
+246 0 obj
+<</Type /StructElem /P 225 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 95>> 248 0 R <</Type /MCR /Pg 247  0 R /MCID 97>> 249 0 R <</Type /MCR /Pg 247  0 R /MCID 99>>] /S /P /Lang(EN)>>
 endobj
-278 0 obj
-<</Type /StructElem /P 275 0 R /K <</Type /MCR /Pg 245  0 R /MCID 126>> /S /Span  /Lang(EN)  >>
+250 0 obj
+<</Type /StructElem /P 225 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 100>>] /S /P /Lang(EN)>>
+endobj
+253 0 obj
+<</Type /StructElem /P 252 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 101>>] /S /Lbl /Lang(EN)  >>
+endobj
+255 0 obj
+<</Type /StructElem /P 254 0 R /K <</Type /MCR /Pg 247  0 R /MCID 103>> /S /Span  /Lang(EN)  >>
+endobj
+254 0 obj
+<</Type /StructElem /P 252 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 102>> 255 0 R <</Type /MCR /Pg 247  0 R /MCID 104>>] /S /LBody /Lang(EN)  >>
+endobj
+252 0 obj
+<</Type /StructElem /P 251 0 R  /Lang(EN)/K [ 253 0 R 254 0 R] /S /LI>>
+endobj
+257 0 obj
+<</Type /StructElem /P 256 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 105>>] /S /Lbl /Lang(EN)  >>
+endobj
+259 0 obj
+<</Type /StructElem /P 258 0 R /K <</Type /MCR /Pg 247  0 R /MCID 107>> /S /Span  /Lang(EN)  >>
+endobj
+258 0 obj
+<</Type /StructElem /P 256 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 106>> 259 0 R <</Type /MCR /Pg 247  0 R /MCID 108>>] /S /LBody /Lang(EN)  >>
+endobj
+256 0 obj
+<</Type /StructElem /P 251 0 R  /Lang(EN)/K [ 257 0 R 258 0 R] /S /LI>>
+endobj
+261 0 obj
+<</Type /StructElem /P 260 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 109>>] /S /Lbl /Lang(EN)  >>
+endobj
+263 0 obj
+<</Type /StructElem /P 262 0 R /K <</Type /MCR /Pg 247  0 R /MCID 111>> /S /Span  /Lang(EN)  >>
+endobj
+262 0 obj
+<</Type /StructElem /P 260 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 110>> 263 0 R <</Type /MCR /Pg 247  0 R /MCID 112>>] /S /LBody /Lang(EN)  >>
+endobj
+260 0 obj
+<</Type /StructElem /P 251 0 R  /Lang(EN)/K [ 261 0 R 262 0 R] /S /LI>>
+endobj
+265 0 obj
+<</Type /StructElem /P 264 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 113>>] /S /Lbl /Lang(EN)  >>
+endobj
+267 0 obj
+<</Type /StructElem /P 266 0 R /K <</Type /MCR /Pg 247  0 R /MCID 115>> /S /Span  /Lang(EN)  >>
+endobj
+266 0 obj
+<</Type /StructElem /P 264 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 114>> 267 0 R <</Type /MCR /Pg 247  0 R /MCID 116>>] /S /LBody /Lang(EN)  >>
+endobj
+264 0 obj
+<</Type /StructElem /P 251 0 R  /Lang(EN)/K [ 265 0 R 266 0 R] /S /LI>>
+endobj
+269 0 obj
+<</Type /StructElem /P 268 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 117>>] /S /Lbl /Lang(EN)  >>
+endobj
+270 0 obj
+<</Type /StructElem /P 268 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 118>>] /S /LBody /Lang(EN)  >>
+endobj
+268 0 obj
+<</Type /StructElem /P 251 0 R  /Lang(EN)/K [ 269 0 R 270 0 R] /S /LI>>
+endobj
+272 0 obj
+<</Type /StructElem /P 271 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 119>>] /S /Lbl /Lang(EN)  >>
+endobj
+273 0 obj
+<</Type /StructElem /P 271 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 120>>] /S /LBody /Lang(EN)  >>
+endobj
+271 0 obj
+<</Type /StructElem /P 251 0 R  /Lang(EN)/K [ 272 0 R 273 0 R] /S /LI>>
 endobj
 275 0 obj
-<</Type /StructElem /P 223 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 123>>276 0 R   <</Type /MCR /Pg 245  0 R /MCID 125>> 278 0 R <</Type /MCR /Pg 245  0 R /MCID 127>>] /S /P /Lang(EN)>>
+<</Type /StructElem /P 274 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 121>>] /S /Lbl /Lang(EN)  >>
+endobj
+276 0 obj
+<</Type /StructElem /P 274 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 122>>] /S /LBody /Lang(EN)  >>
+endobj
+274 0 obj
+<</Type /StructElem /P 251 0 R  /Lang(EN)/K [ 275 0 R 276 0 R] /S /LI>>
+endobj
+251 0 obj
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 252 0 R 256 0 R 260 0 R 264 0 R 268 0 R 271 0 R 274 0 R] /S /L1>>
+endobj
+278 0 obj
+<</Type /StructElem /P 277 0 R /K [<</Type /MCR /Pg 247  0 R /MCID 124>> <</Type /OBJR /Obj 279 0 R>>] /S /Reference>>
 endobj
 280 0 obj
-<</Type /StructElem /P 279 0 R /K <</Type /MCR /Pg 245  0 R /MCID 129>> /S /Span  /Lang(EN)  >>
+<</Type /StructElem /P 277 0 R /K <</Type /MCR /Pg 247  0 R /MCID 126>> /S /Span  /Lang(EN)  >>
 endobj
-281 0 obj
-<</Type /StructElem /P 279 0 R /K <</Type /MCR /Pg 245  0 R /MCID 131>> /S /Span  /Lang(EN)  >>
-endobj
-279 0 obj
-<</Type /StructElem /P 223 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 128>> 280 0 R <</Type /MCR /Pg 245  0 R /MCID 130>> 281 0 R <</Type /MCR /Pg 245  0 R /MCID 132>>] /S /Caption /Lang(EN)  >>
+277 0 obj
+<</Type /StructElem /P 225 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 123>>278 0 R   <</Type /MCR /Pg 247  0 R /MCID 125>> 280 0 R <</Type /MCR /Pg 247  0 R /MCID 127>>] /S /P /Lang(EN)>>
 endobj
 282 0 obj
-<</Type /StructElem /P 223 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 133>>] /S /P /Lang(EN)>>
+<</Type /StructElem /P 281 0 R /K <</Type /MCR /Pg 247  0 R /MCID 129>> /S /Span  /Lang(EN)  >>
 endobj
 283 0 obj
-<</Type /StructElem /P 223 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 134>>] /S /P /Lang(EN)>>
+<</Type /StructElem /P 281 0 R /K <</Type /MCR /Pg 247  0 R /MCID 131>> /S /Span  /Lang(EN)  >>
+endobj
+281 0 obj
+<</Type /StructElem /P 225 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 128>> 282 0 R <</Type /MCR /Pg 247  0 R /MCID 130>> 283 0 R <</Type /MCR /Pg 247  0 R /MCID 132>>] /S /Caption /Lang(EN)  >>
 endobj
 284 0 obj
-<</Type /StructElem /P 223 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 135>>] /S /P /Lang(EN)>>
+<</Type /StructElem /P 225 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 133>>] /S /P /Lang(EN)>>
 endobj
 285 0 obj
-<</Type /StructElem /P 223 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 136>>] /S /P /Lang(EN)>>
+<</Type /StructElem /P 225 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 134>>] /S /P /Lang(EN)>>
 endobj
 286 0 obj
-<</Type /StructElem /P 223 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 137>>] /S /P /Lang(EN)>>
+<</Type /StructElem /P 225 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 135>>] /S /P /Lang(EN)>>
 endobj
 287 0 obj
-<</Type /StructElem /P 223 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 138>>] /S /P /Lang(EN)>>
-endobj
-289 0 obj
-<</Type /StructElem /P 288 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 139>> <</Type /MCR /Pg 245  0 R /MCID 140>> <</Type /MCR /Pg 245  0 R /MCID 141>> <</Type /MCR /Pg 245  0 R /MCID 142>> <</Type /MCR /Pg 245  0 R /MCID 143>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 225 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 136>>] /S /P /Lang(EN)>>
 endobj
 288 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 289 0 R] /S /TR>>
+<</Type /StructElem /P 225 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 137>>] /S /P /Lang(EN)>>
+endobj
+289 0 obj
+<</Type /StructElem /P 225 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 138>>] /S /P /Lang(EN)>>
 endobj
 291 0 obj
-<</Type /StructElem /P 290 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 144>> <</Type /MCR /Pg 245  0 R /MCID 145>> <</Type /MCR /Pg 245  0 R /MCID 146>> <</Type /MCR /Pg 245  0 R /MCID 147>> <</Type /MCR /Pg 245  0 R /MCID 148>> <</Type /MCR /Pg 245  0 R /MCID 149>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 290 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 139>> <</Type /MCR /Pg 247  0 R /MCID 140>> <</Type /MCR /Pg 247  0 R /MCID 141>> <</Type /MCR /Pg 247  0 R /MCID 142>> <</Type /MCR /Pg 247  0 R /MCID 143>>] /S /TD /Lang(EN)  >>
 endobj
 290 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 291 0 R] /S /TR>>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 291 0 R] /S /TR>>
 endobj
 293 0 obj
-<</Type /StructElem /P 292 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 150>> <</Type /MCR /Pg 245  0 R /MCID 151>> <</Type /MCR /Pg 245  0 R /MCID 152>> <</Type /MCR /Pg 245  0 R /MCID 153>> <</Type /MCR /Pg 245  0 R /MCID 154>> <</Type /MCR /Pg 245  0 R /MCID 155>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 292 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 144>> <</Type /MCR /Pg 247  0 R /MCID 145>> <</Type /MCR /Pg 247  0 R /MCID 146>> <</Type /MCR /Pg 247  0 R /MCID 147>> <</Type /MCR /Pg 247  0 R /MCID 148>> <</Type /MCR /Pg 247  0 R /MCID 149>>] /S /TD /Lang(EN)  >>
 endobj
 292 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 293 0 R] /S /TR>>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 293 0 R] /S /TR>>
 endobj
 295 0 obj
-<</Type /StructElem /P 294 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 156>> <</Type /MCR /Pg 245  0 R /MCID 157>> <</Type /MCR /Pg 245  0 R /MCID 158>> <</Type /MCR /Pg 245  0 R /MCID 159>> <</Type /MCR /Pg 245  0 R /MCID 160>> <</Type /MCR /Pg 245  0 R /MCID 161>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 294 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 150>> <</Type /MCR /Pg 247  0 R /MCID 151>> <</Type /MCR /Pg 247  0 R /MCID 152>> <</Type /MCR /Pg 247  0 R /MCID 153>> <</Type /MCR /Pg 247  0 R /MCID 154>> <</Type /MCR /Pg 247  0 R /MCID 155>>] /S /TD /Lang(EN)  >>
 endobj
 294 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 295 0 R] /S /TR>>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 295 0 R] /S /TR>>
 endobj
 297 0 obj
-<</Type /StructElem /P 296 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 162>> <</Type /MCR /Pg 245  0 R /MCID 163>> <</Type /MCR /Pg 245  0 R /MCID 164>> <</Type /MCR /Pg 245  0 R /MCID 165>> <</Type /MCR /Pg 245  0 R /MCID 166>> <</Type /MCR /Pg 245  0 R /MCID 167>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 296 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 156>> <</Type /MCR /Pg 247  0 R /MCID 157>> <</Type /MCR /Pg 247  0 R /MCID 158>> <</Type /MCR /Pg 247  0 R /MCID 159>> <</Type /MCR /Pg 247  0 R /MCID 160>> <</Type /MCR /Pg 247  0 R /MCID 161>>] /S /TD /Lang(EN)  >>
 endobj
 296 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 297 0 R] /S /TR>>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 297 0 R] /S /TR>>
 endobj
 299 0 obj
-<</Type /StructElem /P 298 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 168>> <</Type /MCR /Pg 245  0 R /MCID 169>> <</Type /MCR /Pg 245  0 R /MCID 170>> <</Type /MCR /Pg 245  0 R /MCID 171>> <</Type /MCR /Pg 245  0 R /MCID 172>> <</Type /MCR /Pg 245  0 R /MCID 173>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 298 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 162>> <</Type /MCR /Pg 247  0 R /MCID 163>> <</Type /MCR /Pg 247  0 R /MCID 164>> <</Type /MCR /Pg 247  0 R /MCID 165>> <</Type /MCR /Pg 247  0 R /MCID 166>> <</Type /MCR /Pg 247  0 R /MCID 167>>] /S /TD /Lang(EN)  >>
 endobj
 298 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 299 0 R] /S /TR>>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 299 0 R] /S /TR>>
 endobj
 301 0 obj
-<</Type /StructElem /P 300 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 174>> <</Type /MCR /Pg 245  0 R /MCID 175>> <</Type /MCR /Pg 245  0 R /MCID 176>> <</Type /MCR /Pg 245  0 R /MCID 177>> <</Type /MCR /Pg 245  0 R /MCID 178>> <</Type /MCR /Pg 245  0 R /MCID 179>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 300 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 168>> <</Type /MCR /Pg 247  0 R /MCID 169>> <</Type /MCR /Pg 247  0 R /MCID 170>> <</Type /MCR /Pg 247  0 R /MCID 171>> <</Type /MCR /Pg 247  0 R /MCID 172>> <</Type /MCR /Pg 247  0 R /MCID 173>>] /S /TD /Lang(EN)  >>
 endobj
 300 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 301 0 R] /S /TR>>
-endobj
-304 0 obj
-<</Type /StructElem /P 303 0 R /K <</Type /MCR /Pg 245  0 R /MCID 185>> /S /Span  /Lang(EN)  >>
-endobj
-305 0 obj
-<</Type /StructElem /P 303 0 R /K [<</Type /MCR /Pg 245  0 R /MCID 187>> <</Type /OBJR /Obj 306 0 R>>] /S /Reference>>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 301 0 R] /S /TR>>
 endobj
 303 0 obj
-<</Type /StructElem /P 302 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 180>> <</Type /MCR /Pg 245  0 R /MCID 181>> <</Type /MCR /Pg 245  0 R /MCID 182>> <</Type /MCR /Pg 245  0 R /MCID 183>> <</Type /MCR /Pg 245  0 R /MCID 184>> 304 0 R <</Type /MCR /Pg 245  0 R /MCID 186>>305 0 R   <</Type /MCR /Pg 245  0 R /MCID 188>> <</Type /MCR /Pg 245  0 R /MCID 189>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 302 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 174>> <</Type /MCR /Pg 247  0 R /MCID 175>> <</Type /MCR /Pg 247  0 R /MCID 176>> <</Type /MCR /Pg 247  0 R /MCID 177>> <</Type /MCR /Pg 247  0 R /MCID 178>> <</Type /MCR /Pg 247  0 R /MCID 179>>] /S /TD /Lang(EN)  >>
 endobj
 302 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 303 0 R] /S /TR>>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 303 0 R] /S /TR>>
 endobj
-309 0 obj
-<</Type /StructElem /P 308 0 R /K <</Type /MCR /Pg 245  0 R /MCID 195>> /S /Code  /Lang(EN)  >>
-endobj
-310 0 obj
-<</Type /StructElem /P 308 0 R /K <</Type /MCR /Pg 245  0 R /MCID 197>> /S /Code  /Lang(EN)  >>
-endobj
-311 0 obj
-<</Type /StructElem /P 308 0 R /K <</Type /MCR /Pg 245  0 R /MCID 199>> /S /Code  /Lang(EN)  >>
-endobj
-308 0 obj
-<</Type /StructElem /P 307 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 190>> <</Type /MCR /Pg 245  0 R /MCID 191>> <</Type /MCR /Pg 245  0 R /MCID 192>> <</Type /MCR /Pg 245  0 R /MCID 193>> <</Type /MCR /Pg 245  0 R /MCID 194>> 309 0 R <</Type /MCR /Pg 245  0 R /MCID 196>> 310 0 R <</Type /MCR /Pg 245  0 R /MCID 198>> 311 0 R <</Type /MCR /Pg 245  0 R /MCID 200>> <</Type /MCR /Pg 245  0 R /MCID 201>>] /S /TD /Lang(EN)  >>
+306 0 obj
+<</Type /StructElem /P 305 0 R /K <</Type /MCR /Pg 247  0 R /MCID 185>> /S /Span  /Lang(EN)  >>
 endobj
 307 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 308 0 R] /S /TR>>
+<</Type /StructElem /P 305 0 R /K [<</Type /MCR /Pg 247  0 R /MCID 187>> <</Type /OBJR /Obj 308 0 R>>] /S /Reference>>
 endobj
-313 0 obj
-<</Type /StructElem /P 312 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 202>> <</Type /MCR /Pg 245  0 R /MCID 203>> <</Type /MCR /Pg 245  0 R /MCID 204>> <</Type /MCR /Pg 245  0 R /MCID 205>> <</Type /MCR /Pg 245  0 R /MCID 206>> <</Type /MCR /Pg 245  0 R /MCID 207>>] /S /TD /Lang(EN)  >>
+305 0 obj
+<</Type /StructElem /P 304 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 180>> <</Type /MCR /Pg 247  0 R /MCID 181>> <</Type /MCR /Pg 247  0 R /MCID 182>> <</Type /MCR /Pg 247  0 R /MCID 183>> <</Type /MCR /Pg 247  0 R /MCID 184>> 306 0 R <</Type /MCR /Pg 247  0 R /MCID 186>>307 0 R   <</Type /MCR /Pg 247  0 R /MCID 188>> <</Type /MCR /Pg 247  0 R /MCID 189>>] /S /TD /Lang(EN)  >>
+endobj
+304 0 obj
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 305 0 R] /S /TR>>
+endobj
+311 0 obj
+<</Type /StructElem /P 310 0 R /K <</Type /MCR /Pg 247  0 R /MCID 195>> /S /Code  /Lang(EN)  >>
 endobj
 312 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 313 0 R] /S /TR>>
+<</Type /StructElem /P 310 0 R /K <</Type /MCR /Pg 247  0 R /MCID 197>> /S /Code  /Lang(EN)  >>
+endobj
+313 0 obj
+<</Type /StructElem /P 310 0 R /K <</Type /MCR /Pg 247  0 R /MCID 199>> /S /Code  /Lang(EN)  >>
+endobj
+310 0 obj
+<</Type /StructElem /P 309 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 190>> <</Type /MCR /Pg 247  0 R /MCID 191>> <</Type /MCR /Pg 247  0 R /MCID 192>> <</Type /MCR /Pg 247  0 R /MCID 193>> <</Type /MCR /Pg 247  0 R /MCID 194>> 311 0 R <</Type /MCR /Pg 247  0 R /MCID 196>> 312 0 R <</Type /MCR /Pg 247  0 R /MCID 198>> 313 0 R <</Type /MCR /Pg 247  0 R /MCID 200>> <</Type /MCR /Pg 247  0 R /MCID 201>>] /S /TD /Lang(EN)  >>
+endobj
+309 0 obj
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 310 0 R] /S /TR>>
 endobj
 315 0 obj
-<</Type /StructElem /P 314 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 208>> <</Type /MCR /Pg 245  0 R /MCID 209>> <</Type /MCR /Pg 245  0 R /MCID 210>> <</Type /MCR /Pg 245  0 R /MCID 211>> <</Type /MCR /Pg 245  0 R /MCID 212>> <</Type /MCR /Pg 245  0 R /MCID 213>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 314 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 202>> <</Type /MCR /Pg 247  0 R /MCID 203>> <</Type /MCR /Pg 247  0 R /MCID 204>> <</Type /MCR /Pg 247  0 R /MCID 205>> <</Type /MCR /Pg 247  0 R /MCID 206>> <</Type /MCR /Pg 247  0 R /MCID 207>>] /S /TD /Lang(EN)  >>
 endobj
 314 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 315 0 R] /S /TR>>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 315 0 R] /S /TR>>
 endobj
 317 0 obj
-<</Type /StructElem /P 316 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 214>> <</Type /MCR /Pg 245  0 R /MCID 215>> <</Type /MCR /Pg 245  0 R /MCID 216>> <</Type /MCR /Pg 245  0 R /MCID 217>> <</Type /MCR /Pg 245  0 R /MCID 218>> <</Type /MCR /Pg 245  0 R /MCID 219>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 316 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 208>> <</Type /MCR /Pg 247  0 R /MCID 209>> <</Type /MCR /Pg 247  0 R /MCID 210>> <</Type /MCR /Pg 247  0 R /MCID 211>> <</Type /MCR /Pg 247  0 R /MCID 212>> <</Type /MCR /Pg 247  0 R /MCID 213>>] /S /TD /Lang(EN)  >>
 endobj
 316 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 317 0 R] /S /TR>>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 317 0 R] /S /TR>>
 endobj
 319 0 obj
-<</Type /StructElem /P 318 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 220>> <</Type /MCR /Pg 245  0 R /MCID 221>> <</Type /MCR /Pg 245  0 R /MCID 222>> <</Type /MCR /Pg 245  0 R /MCID 223>> <</Type /MCR /Pg 245  0 R /MCID 224>> <</Type /MCR /Pg 245  0 R /MCID 225>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 318 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 214>> <</Type /MCR /Pg 247  0 R /MCID 215>> <</Type /MCR /Pg 247  0 R /MCID 216>> <</Type /MCR /Pg 247  0 R /MCID 217>> <</Type /MCR /Pg 247  0 R /MCID 218>> <</Type /MCR /Pg 247  0 R /MCID 219>>] /S /TD /Lang(EN)  >>
 endobj
 318 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 319 0 R] /S /TR>>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 319 0 R] /S /TR>>
 endobj
 321 0 obj
-<</Type /StructElem /P 320 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 226>> <</Type /MCR /Pg 245  0 R /MCID 227>> <</Type /MCR /Pg 245  0 R /MCID 228>> <</Type /MCR /Pg 245  0 R /MCID 229>> <</Type /MCR /Pg 245  0 R /MCID 230>> <</Type /MCR /Pg 245  0 R /MCID 231>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 320 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 220>> <</Type /MCR /Pg 247  0 R /MCID 221>> <</Type /MCR /Pg 247  0 R /MCID 222>> <</Type /MCR /Pg 247  0 R /MCID 223>> <</Type /MCR /Pg 247  0 R /MCID 224>> <</Type /MCR /Pg 247  0 R /MCID 225>>] /S /TD /Lang(EN)  >>
 endobj
 320 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 321 0 R] /S /TR>>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 321 0 R] /S /TR>>
 endobj
 323 0 obj
-<</Type /StructElem /P 322 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 232>> <</Type /MCR /Pg 245  0 R /MCID 233>> <</Type /MCR /Pg 245  0 R /MCID 234>> <</Type /MCR /Pg 245  0 R /MCID 235>> <</Type /MCR /Pg 245  0 R /MCID 236>> <</Type /MCR /Pg 245  0 R /MCID 237>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 322 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 226>> <</Type /MCR /Pg 247  0 R /MCID 227>> <</Type /MCR /Pg 247  0 R /MCID 228>> <</Type /MCR /Pg 247  0 R /MCID 229>> <</Type /MCR /Pg 247  0 R /MCID 230>> <</Type /MCR /Pg 247  0 R /MCID 231>>] /S /TD /Lang(EN)  >>
 endobj
 322 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 323 0 R] /S /TR>>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 323 0 R] /S /TR>>
 endobj
 325 0 obj
-<</Type /StructElem /P 324 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 238>> <</Type /MCR /Pg 245  0 R /MCID 239>> <</Type /MCR /Pg 245  0 R /MCID 240>> <</Type /MCR /Pg 245  0 R /MCID 241>> <</Type /MCR /Pg 245  0 R /MCID 242>> <</Type /MCR /Pg 245  0 R /MCID 243>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 324 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 232>> <</Type /MCR /Pg 247  0 R /MCID 233>> <</Type /MCR /Pg 247  0 R /MCID 234>> <</Type /MCR /Pg 247  0 R /MCID 235>> <</Type /MCR /Pg 247  0 R /MCID 236>> <</Type /MCR /Pg 247  0 R /MCID 237>>] /S /TD /Lang(EN)  >>
 endobj
 324 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 325 0 R] /S /TR>>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 325 0 R] /S /TR>>
 endobj
 327 0 obj
-<</Type /StructElem /P 326 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 244>> <</Type /MCR /Pg 245  0 R /MCID 245>> <</Type /MCR /Pg 245  0 R /MCID 246>> <</Type /MCR /Pg 245  0 R /MCID 247>> <</Type /MCR /Pg 245  0 R /MCID 248>> <</Type /MCR /Pg 245  0 R /MCID 249>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 326 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 238>> <</Type /MCR /Pg 247  0 R /MCID 239>> <</Type /MCR /Pg 247  0 R /MCID 240>> <</Type /MCR /Pg 247  0 R /MCID 241>> <</Type /MCR /Pg 247  0 R /MCID 242>> <</Type /MCR /Pg 247  0 R /MCID 243>>] /S /TD /Lang(EN)  >>
 endobj
 326 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 327 0 R] /S /TR>>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 327 0 R] /S /TR>>
 endobj
 329 0 obj
-<</Type /StructElem /P 328 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 250>> <</Type /MCR /Pg 245  0 R /MCID 251>> <</Type /MCR /Pg 245  0 R /MCID 252>> <</Type /MCR /Pg 245  0 R /MCID 253>> <</Type /MCR /Pg 245  0 R /MCID 254>> <</Type /MCR /Pg 245  0 R /MCID 255>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 328 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 244>> <</Type /MCR /Pg 247  0 R /MCID 245>> <</Type /MCR /Pg 247  0 R /MCID 246>> <</Type /MCR /Pg 247  0 R /MCID 247>> <</Type /MCR /Pg 247  0 R /MCID 248>> <</Type /MCR /Pg 247  0 R /MCID 249>>] /S /TD /Lang(EN)  >>
 endobj
 328 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 329 0 R] /S /TR>>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 329 0 R] /S /TR>>
 endobj
 331 0 obj
-<</Type /StructElem /P 330 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 256>> <</Type /MCR /Pg 245  0 R /MCID 257>> <</Type /MCR /Pg 245  0 R /MCID 258>> <</Type /MCR /Pg 245  0 R /MCID 259>> <</Type /MCR /Pg 245  0 R /MCID 260>> <</Type /MCR /Pg 245  0 R /MCID 261>> <</Type /MCR /Pg 245  0 R /MCID 262>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 330 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 250>> <</Type /MCR /Pg 247  0 R /MCID 251>> <</Type /MCR /Pg 247  0 R /MCID 252>> <</Type /MCR /Pg 247  0 R /MCID 253>> <</Type /MCR /Pg 247  0 R /MCID 254>> <</Type /MCR /Pg 247  0 R /MCID 255>>] /S /TD /Lang(EN)  >>
 endobj
 330 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 331 0 R] /S /TR>>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 331 0 R] /S /TR>>
 endobj
 333 0 obj
-<</Type /StructElem /P 332 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 263>> <</Type /MCR /Pg 245  0 R /MCID 264>> <</Type /MCR /Pg 245  0 R /MCID 265>> <</Type /MCR /Pg 245  0 R /MCID 266>> <</Type /MCR /Pg 245  0 R /MCID 267>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 332 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 256>> <</Type /MCR /Pg 247  0 R /MCID 257>> <</Type /MCR /Pg 247  0 R /MCID 258>> <</Type /MCR /Pg 247  0 R /MCID 259>> <</Type /MCR /Pg 247  0 R /MCID 260>> <</Type /MCR /Pg 247  0 R /MCID 261>> <</Type /MCR /Pg 247  0 R /MCID 262>>] /S /TD /Lang(EN)  >>
 endobj
 332 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 333 0 R] /S /TR>>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 333 0 R] /S /TR>>
 endobj
 335 0 obj
-<</Type /StructElem /P 334 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 268>> <</Type /MCR /Pg 245  0 R /MCID 269>> <</Type /MCR /Pg 245  0 R /MCID 270>> <</Type /MCR /Pg 245  0 R /MCID 271>> <</Type /MCR /Pg 245  0 R /MCID 272>> <</Type /MCR /Pg 245  0 R /MCID 273>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 334 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 263>> <</Type /MCR /Pg 247  0 R /MCID 264>> <</Type /MCR /Pg 247  0 R /MCID 265>> <</Type /MCR /Pg 247  0 R /MCID 266>> <</Type /MCR /Pg 247  0 R /MCID 267>>] /S /TD /Lang(EN)  >>
 endobj
 334 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 335 0 R] /S /TR>>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 335 0 R] /S /TR>>
 endobj
 337 0 obj
-<</Type /StructElem /P 336 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 274>> <</Type /MCR /Pg 245  0 R /MCID 275>> <</Type /MCR /Pg 245  0 R /MCID 276>> <</Type /MCR /Pg 245  0 R /MCID 277>> <</Type /MCR /Pg 245  0 R /MCID 278>> <</Type /MCR /Pg 245  0 R /MCID 279>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 336 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 268>> <</Type /MCR /Pg 247  0 R /MCID 269>> <</Type /MCR /Pg 247  0 R /MCID 270>> <</Type /MCR /Pg 247  0 R /MCID 271>> <</Type /MCR /Pg 247  0 R /MCID 272>> <</Type /MCR /Pg 247  0 R /MCID 273>>] /S /TD /Lang(EN)  >>
 endobj
 336 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 337 0 R] /S /TR>>
-endobj
-340 0 obj
-<</Type /StructElem /P 339 0 R /K <</Type /MCR /Pg 245  0 R /MCID 285>> /S /Span  /Lang(EN)  >>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 337 0 R] /S /TR>>
 endobj
 339 0 obj
-<</Type /StructElem /P 338 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 280>> <</Type /MCR /Pg 245  0 R /MCID 281>> <</Type /MCR /Pg 245  0 R /MCID 282>> <</Type /MCR /Pg 245  0 R /MCID 283>> <</Type /MCR /Pg 245  0 R /MCID 284>> 340 0 R <</Type /MCR /Pg 245  0 R /MCID 286>> <</Type /MCR /Pg 245  0 R /MCID 287>> <</Type /MCR /Pg 245  0 R /MCID 288>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 338 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 274>> <</Type /MCR /Pg 247  0 R /MCID 275>> <</Type /MCR /Pg 247  0 R /MCID 276>> <</Type /MCR /Pg 247  0 R /MCID 277>> <</Type /MCR /Pg 247  0 R /MCID 278>> <</Type /MCR /Pg 247  0 R /MCID 279>>] /S /TD /Lang(EN)  >>
 endobj
 338 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 339 0 R] /S /TR>>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 339 0 R] /S /TR>>
 endobj
 342 0 obj
-<</Type /StructElem /P 341 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 289>> <</Type /MCR /Pg 245  0 R /MCID 290>> <</Type /MCR /Pg 245  0 R /MCID 291>> <</Type /MCR /Pg 245  0 R /MCID 292>> <</Type /MCR /Pg 245  0 R /MCID 293>>] /S /TD /Lang(EN)  >>
+<</Type /StructElem /P 341 0 R /K <</Type /MCR /Pg 247  0 R /MCID 285>> /S /Span  /Lang(EN)  >>
 endobj
 341 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 342 0 R] /S /TR>>
+<</Type /StructElem /P 340 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 280>> <</Type /MCR /Pg 247  0 R /MCID 281>> <</Type /MCR /Pg 247  0 R /MCID 282>> <</Type /MCR /Pg 247  0 R /MCID 283>> <</Type /MCR /Pg 247  0 R /MCID 284>> 342 0 R <</Type /MCR /Pg 247  0 R /MCID 286>> <</Type /MCR /Pg 247  0 R /MCID 287>> <</Type /MCR /Pg 247  0 R /MCID 288>>] /S /TD /Lang(EN)  >>
 endobj
-347 0 obj
-<</Type /StructElem /P 346 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 297>>] /S /Lbl /Lang(EN)  >>
+340 0 obj
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 341 0 R] /S /TR>>
 endobj
-348 0 obj
-<</Type /StructElem /P 346 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 298>>] /S /LBody /Lang(EN)  >>
-endobj
-346 0 obj
-<</Type /StructElem /P 345 0 R  /Lang(EN)/K [ 347 0 R 348 0 R] /S /LI>>
-endobj
-350 0 obj
-<</Type /StructElem /P 349 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 299>>] /S /Lbl /Lang(EN)  >>
-endobj
-351 0 obj
-<</Type /StructElem /P 349 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 300>>] /S /LBody /Lang(EN)  >>
-endobj
-349 0 obj
-<</Type /StructElem /P 345 0 R  /Lang(EN)/K [ 350 0 R 351 0 R] /S /LI>>
-endobj
-345 0 obj
-<</Type /StructElem /P 343 0 R  /Lang(EN)/K [ 346 0 R 349 0 R] /S /L1>>
+344 0 obj
+<</Type /StructElem /P 343 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 289>> <</Type /MCR /Pg 247  0 R /MCID 290>> <</Type /MCR /Pg 247  0 R /MCID 291>> <</Type /MCR /Pg 247  0 R /MCID 292>> <</Type /MCR /Pg 247  0 R /MCID 293>>] /S /TD /Lang(EN)  >>
 endobj
 343 0 obj
-<</Type /StructElem /P 223 0 R  /Lang(EN)/K [ 345 0 R] /S /TR>>
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 344 0 R] /S /TR>>
 endobj
-223 0 obj
-<</Type /StructElem /P 191 0 R /T (A ``meta'' LaTeX style file) /Lang(EN)/K [ 224 0 R 225 0 R 229 0 R 244 0 R 248 0 R 249 0 R 275 0 R 279 0 R 282 0 R 283 0 R 284 0 R 285 0 R 286 0 R 287 0 R 288 0 R 290 0 R 292 0 R 294 0 R 296 0 R 298 0 R 300 0 R 302 0 R 307 0 R 312 0 R 314 0 R 316 0 R 318 0 R 320 0 R 322 0 R 324 0 R 326 0 R 328 0 R 330 0 R 332 0 R 334 0 R 336 0 R 338 0 R 341 0 R 343 0 R] /S /Subsection>>
+349 0 obj
+<</Type /StructElem /P 348 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 297>>] /S /Lbl /Lang(EN)  >>
+endobj
+350 0 obj
+<</Type /StructElem /P 348 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 298>>] /S /LBody /Lang(EN)  >>
+endobj
+348 0 obj
+<</Type /StructElem /P 347 0 R  /Lang(EN)/K [ 349 0 R 350 0 R] /S /LI>>
+endobj
+352 0 obj
+<</Type /StructElem /P 351 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 299>>] /S /Lbl /Lang(EN)  >>
 endobj
 353 0 obj
-<</Type /StructElem /P 352 0 R /K [ <</Type /MCR /Pg 245 0 R /MCID 301>> <</Type /MCR /Pg 245  0 R /MCID 302>>] /S /H /Lang(EN)  >>
+<</Type /StructElem /P 351 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 300>>] /S /LBody /Lang(EN)  >>
+endobj
+351 0 obj
+<</Type /StructElem /P 347 0 R  /Lang(EN)/K [ 352 0 R 353 0 R] /S /LI>>
+endobj
+347 0 obj
+<</Type /StructElem /P 345 0 R  /Lang(EN)/K [ 348 0 R 351 0 R] /S /L1>>
+endobj
+345 0 obj
+<</Type /StructElem /P 225 0 R  /Lang(EN)/K [ 347 0 R] /S /TR>>
+endobj
+225 0 obj
+<</Type /StructElem /P 193 0 R /T (A ``meta'' LaTeX style file) /Lang(EN)/K [ 226 0 R 227 0 R 231 0 R 246 0 R 250 0 R 251 0 R 277 0 R 281 0 R 284 0 R 285 0 R 286 0 R 287 0 R 288 0 R 289 0 R 290 0 R 292 0 R 294 0 R 296 0 R 298 0 R 300 0 R 302 0 R 304 0 R 309 0 R 314 0 R 316 0 R 318 0 R 320 0 R 322 0 R 324 0 R 326 0 R 328 0 R 330 0 R 332 0 R 334 0 R 336 0 R 338 0 R 340 0 R 343 0 R 345 0 R] /S /Subsection>>
 endobj
 355 0 obj
-<</Type /StructElem /P 354 0 R /K <</Type /MCR /Pg 245  0 R /MCID 304>> /S /Span  /Lang(EN)  >>
-endobj
-354 0 obj
-<</Type /StructElem /P 352 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 303>> 355 0 R <</Type /MCR /Pg 245  0 R /MCID 305>>] /S /P /Lang(EN)>>
+<</Type /StructElem /P 354 0 R /K [ <</Type /MCR /Pg 247 0 R /MCID 301>> <</Type /MCR /Pg 247  0 R /MCID 302>>] /S /H /Lang(EN)  >>
 endobj
 357 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 306>>] /S /H /Lang(EN)  >>
-endobj
-358 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 307>>] /S /P /Lang(EN)>>
-endobj
-359 0 obj
-<</Type /StructElem /P 356 0 R /K [] /S /Formula /Lang(EN)  >>
-endobj
-362 0 obj
-<</Type /StructElem /P 361 0 R /K <</Type /MCR /Pg 245  0 R /MCID 309>> /S /Span  /Lang(EN)  >>
-endobj
-363 0 obj
-<</Type /StructElem /P 361 0 R /K <</Type /MCR /Pg 245  0 R /MCID 311>> /S /Code  /Lang(EN)  >>
-endobj
-361 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 308>> 362 0 R <</Type /MCR /Pg 245  0 R /MCID 310>> 363 0 R <</Type /MCR /Pg 245  0 R /MCID 312>>] /S /P /Lang(EN)>>
-endobj
-365 0 obj
-<</Type /StructElem /P 364 0 R /K [<</Type /MCR /Pg 245  0 R /MCID 314>> <</Type /OBJR /Obj 366 0 R>>] /S /Reference>>
-endobj
-364 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 313>>365 0 R   <</Type /MCR /Pg 245  0 R /MCID 315>>] /S /P /Lang(EN)>>
-endobj
-367 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 316>>] /S /P /Lang(EN)>>
-endobj
-368 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 317>>] /S /P /Lang(EN)>>
-endobj
-369 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 318>>] /S /Figure /Lang(EN)  >>
-endobj
-371 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 319>>] /S /Figure /Lang(EN)  >>
-endobj
-372 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 320>>] /S /Figure /Lang(EN)  >>
-endobj
-374 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 321>>] /S /Figure /Lang(EN)  >>
-endobj
-375 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 322>>] /S /P /Lang(EN)>>
-endobj
-376 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 323>>] /S /P /Lang(EN)>>
-endobj
-377 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 324>>] /S /P /Lang(EN)>>
-endobj
-378 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 325>>] /S /Figure /Lang(EN)  >>
-endobj
-379 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 326>>] /S /Figure /Lang(EN)  >>
-endobj
-380 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 327>>] /S /Figure /Lang(EN)  >>
-endobj
-382 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 328>>] /S /Figure /Lang(EN)  >>
-endobj
-383 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 329>>] /S /P /Lang(EN)>>
-endobj
-384 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 330>>] /S /P /Lang(EN)>>
-endobj
-385 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 331>>] /S /Caption /Lang(EN)  >>
-endobj
-386 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 332>>] /S /P /Lang(EN)>>
-endobj
-388 0 obj
-<</Type /StructElem /P 387 0 R /K <</Type /MCR /Pg 245  0 R /MCID 334>> /S /Span  /Lang(EN)  >>
-endobj
-389 0 obj
-<</Type /StructElem /P 387 0 R /K <</Type /MCR /Pg 245  0 R /MCID 336>> /S /Code  /Lang(EN)  >>
-endobj
-387 0 obj
-<</Type /StructElem /P 356 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 333>> 388 0 R <</Type /MCR /Pg 245  0 R /MCID 335>> 389 0 R <</Type /MCR /Pg 245  0 R /MCID 337>>] /S /P /Lang(EN)>>
-endobj
-390 0 obj
-<</Type /StructElem /P 356 0 R /K [] /S /Formula /Lang(EN)  /Alt(a squared plus b squared equals c squared)>>
+<</Type /StructElem /P 356 0 R /K <</Type /MCR /Pg 247  0 R /MCID 304>> /S /Span  /Lang(EN)  >>
 endobj
 356 0 obj
-<</Type /StructElem /P 352 0 R /T (Alternative text) /Lang(EN)/K [ 357 0 R 358 0 R 359 0 R 361 0 R 364 0 R 367 0 R 368 0 R 369 0 R 371 0 R 372 0 R 374 0 R 375 0 R 376 0 R 377 0 R 378 0 R 379 0 R 380 0 R 382 0 R 383 0 R 384 0 R 385 0 R 386 0 R 387 0 R 390 0 R] /S /Subsubsection>>
+<</Type /StructElem /P 354 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 303>> 357 0 R <</Type /MCR /Pg 247  0 R /MCID 305>>] /S /P /Lang(EN)>>
+endobj
+359 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 306>>] /S /H /Lang(EN)  >>
+endobj
+360 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 307>>] /S /P /Lang(EN)>>
+endobj
+361 0 obj
+<</Type /StructElem /P 358 0 R /K [] /S /Formula /Lang(EN)  >>
+endobj
+364 0 obj
+<</Type /StructElem /P 363 0 R /K <</Type /MCR /Pg 247  0 R /MCID 309>> /S /Span  /Lang(EN)  >>
+endobj
+365 0 obj
+<</Type /StructElem /P 363 0 R /K <</Type /MCR /Pg 247  0 R /MCID 311>> /S /Code  /Lang(EN)  >>
+endobj
+363 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 308>> 364 0 R <</Type /MCR /Pg 247  0 R /MCID 310>> 365 0 R <</Type /MCR /Pg 247  0 R /MCID 312>>] /S /P /Lang(EN)>>
+endobj
+367 0 obj
+<</Type /StructElem /P 366 0 R /K [<</Type /MCR /Pg 247  0 R /MCID 314>> <</Type /OBJR /Obj 368 0 R>>] /S /Reference>>
+endobj
+366 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 313>>367 0 R   <</Type /MCR /Pg 247  0 R /MCID 315>>] /S /P /Lang(EN)>>
+endobj
+369 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 316>>] /S /P /Lang(EN)>>
+endobj
+370 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 317>>] /S /P /Lang(EN)>>
+endobj
+371 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 318>>] /S /Figure /Lang(EN)  >>
+endobj
+373 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 319>>] /S /Figure /Lang(EN)  >>
+endobj
+374 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 320>>] /S /Figure /Lang(EN)  >>
+endobj
+376 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 321>>] /S /Figure /Lang(EN)  >>
+endobj
+377 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 322>>] /S /P /Lang(EN)>>
+endobj
+378 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 323>>] /S /P /Lang(EN)>>
+endobj
+379 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 324>>] /S /P /Lang(EN)>>
+endobj
+380 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 325>>] /S /Figure /Lang(EN)  >>
+endobj
+381 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 326>>] /S /Figure /Lang(EN)  >>
+endobj
+382 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 327>>] /S /Figure /Lang(EN)  >>
+endobj
+384 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 328>>] /S /Figure /Lang(EN)  >>
+endobj
+385 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 329>>] /S /P /Lang(EN)>>
+endobj
+386 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 330>>] /S /P /Lang(EN)>>
+endobj
+387 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 331>>] /S /Caption /Lang(EN)  >>
+endobj
+388 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 332>>] /S /P /Lang(EN)>>
+endobj
+390 0 obj
+<</Type /StructElem /P 389 0 R /K <</Type /MCR /Pg 247  0 R /MCID 334>> /S /Span  /Lang(EN)  >>
+endobj
+391 0 obj
+<</Type /StructElem /P 389 0 R /K <</Type /MCR /Pg 247  0 R /MCID 336>> /S /Code  /Lang(EN)  >>
+endobj
+389 0 obj
+<</Type /StructElem /P 358 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 333>> 390 0 R <</Type /MCR /Pg 247  0 R /MCID 335>> 391 0 R <</Type /MCR /Pg 247  0 R /MCID 337>>] /S /P /Lang(EN)>>
 endobj
 392 0 obj
-<</Type /StructElem /P 391 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 338>>] /S /H /Lang(EN)  >>
+<</Type /StructElem /P 358 0 R /K [] /S /Formula /Lang(EN)  /Alt(a squared plus b squared equals c squared)>>
+endobj
+358 0 obj
+<</Type /StructElem /P 354 0 R /T (Alternative text) /Lang(EN)/K [ 359 0 R 360 0 R 361 0 R 363 0 R 366 0 R 369 0 R 370 0 R 371 0 R 373 0 R 374 0 R 376 0 R 377 0 R 378 0 R 379 0 R 380 0 R 381 0 R 382 0 R 384 0 R 385 0 R 386 0 R 387 0 R 388 0 R 389 0 R 392 0 R] /S /Subsubsection>>
 endobj
 394 0 obj
-<</Type /StructElem /P 393 0 R /K <</Type /MCR /Pg 245  0 R /MCID 340>> /S /Span  /Lang(EN)  >>
+<</Type /StructElem /P 393 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 338>>] /S /H /Lang(EN)  >>
 endobj
 396 0 obj
+<</Type /StructElem /P 395 0 R /K <</Type /MCR /Pg 247  0 R /MCID 340>> /S /Span  /Lang(EN)  >>
+endobj
+398 0 obj
 <<
 /Length 45502     
 >>
@@ -3327,16 +3327,16 @@ stream
 /P <</MCID 92>> BDC
 1 0 0 1 -72 -674.037 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 674.037 Td [(This)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(approach)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.004 0 Td [(gi)25(v)15(es)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.123 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(single)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.291 0 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.222 0 Td [(which)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.84 0 Td [(contains)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.695 0 Td [(all)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(of)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 674.037 Td [(This)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(approach)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.004 0 Td [(gi)25(v)15(es)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.123 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(single)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.291 0 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.222 0 Td [(which)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.84 0 Td [(contains)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.695 0 Td [(all)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(of)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -205.746 -11.955 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(formatting)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.552 0 Td [(required)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.686 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(produce)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.58 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(range)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.617 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(documents.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -205.746 -11.955 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(formatting)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.552 0 Td [(required)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.686 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(produce)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.58 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(range)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.617 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(documents.)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -182.046 -11.955 Td [(F)15(or)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.179 0 Td [(e)15(xample,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.585 0 Td [(an)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.896 0 Td [(or)18(g)5(anization)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 52.064 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(w)10(ants)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.634 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(implement)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -182.046 -11.955 Td [(F)15(or)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.179 0 Td [(e)15(xample,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.585 0 Td [(an)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.896 0 Td [(or)18(g)5(anization)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 52.064 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(w)10(ants)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.634 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(implement)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -172.033 -11.955 Td [(an)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(in-house)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.802 0 Td [(L)]TJ/F79 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(publishing)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.562 0 Td [(system)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.167 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.318 0 Td [(customize)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 42.889 0 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -172.033 -11.955 Td [(an)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(in-house)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.802 0 Td [(L)]TJ/F80 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(publishing)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.562 0 Td [(system)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.167 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.318 0 Td [(customize)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 42.889 0 Td [(the)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -3345,32 +3345,32 @@ EMC
 /Span <</MCID 93>> BDC
 1 0 0 1 -72 -626.217 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 72 626.217 Td [(meta.cls)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 72 626.217 Td [(meta.cls)]TJ
 ET
 1 0 0 1 104.926 626.217 cm
 EMC
 /P <</MCID 94>> BDC
 1 0 0 1 -104.926 -626.217 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 107.417 626.217 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(then)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.647 0 Td [(mak)10(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.969 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(class)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(a)20(v)25(ailable)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.007 0 Td [(through)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 33.484 0 Td [(a)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 107.417 626.217 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(then)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.647 0 Td [(mak)10(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.969 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(class)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(a)20(v)25(ailable)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.007 0 Td [(through)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 33.484 0 Td [(a)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -219.146 -11.955 Td [(sub)15(v)15(ersion)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.36 0 Td [(serv)15(er)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.679 0 Td [(from)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(which)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.839 0 Td [(authors)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.821 0 Td [(pick)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.646 0 Td [(up)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(current)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -219.146 -11.955 Td [(sub)15(v)15(ersion)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.36 0 Td [(serv)15(er)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.679 0 Td [(from)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(which)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.839 0 Td [(authors)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.821 0 Td [(pick)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.646 0 Td [(up)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(current)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -199.321 -11.956 Td [(class)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(\002le.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.311 0 Td [(Each)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.406 0 Td [(user)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.088 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.318 0 Td [(then)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.647 0 Td [(install)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.848 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(class)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.222 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(their)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -199.321 -11.956 Td [(class)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(\002le.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.311 0 Td [(Each)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.406 0 Td [(user)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.088 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.318 0 Td [(then)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.647 0 Td [(install)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.848 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(class)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.222 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(their)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -206.463 -11.955 Td [(te)15(x)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.516 0 Td [(structure)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 37.349 0 Td [(or)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(directory)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.455 0 Td [(with)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(their)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(\002les.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.186 0 Td [(Similarly)65(,)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -206.463 -11.955 Td [(te)15(x)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.516 0 Td [(structure)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 37.349 0 Td [(or)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(directory)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.455 0 Td [(with)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(their)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(\002les.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.186 0 Td [(Similarly)65(,)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -189.158 -11.955 Td [(changes)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.58 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(easy)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.194 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(implement)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.111 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(style)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.31 0 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.222 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(roll)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -189.158 -11.955 Td [(changes)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.58 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(easy)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.194 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(implement)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.111 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(style)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.31 0 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.222 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(roll)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -203.096 -11.955 Td [(out)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(users,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.455 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(because)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.022 0 Td [(documents)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.659 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.654 0 Td [(L)]TJ/F79 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X-based)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.686 0 Td [(it)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 8.029 0 Td [(is)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -203.096 -11.955 Td [(out)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(users,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.455 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(because)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.022 0 Td [(documents)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.659 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.654 0 Td [(L)]TJ/F80 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X-based)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.686 0 Td [(it)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 8.029 0 Td [(is)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -221.443 -11.955 Td [(easy)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.194 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(recompile)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 42.33 0 Td [(old)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(documents.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -221.443 -11.955 Td [(easy)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.194 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(recompile)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 42.33 0 Td [(old)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(documents.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -3379,30 +3379,30 @@ EMC
 /P <</MCID 95>> BDC
 1 0 0 1 -72 -535.92 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 535.92 Td [(The)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 535.92 Td [(The)]TJ
 ET
 1 0 0 1 89.982 535.92 cm
 EMC
 /Span <</MCID 96>> BDC
 1 0 0 1 -89.982 -535.92 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 89.982 535.92 Td [(meta)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 89.982 535.92 Td [(meta)]TJ
 ET
 1 0 0 1 109.907 535.92 cm
 EMC
 /P <</MCID 97>> BDC
 1 0 0 1 -109.907 -535.92 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 112.398 535.92 Td [(class)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.135 0 Td [(written)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.715 0 Td [(so)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.347 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(it)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 8.03 0 Td [(will)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.992 0 Td [(accept)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.935 0 Td [(all)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(of)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 112.398 535.92 Td [(class)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.135 0 Td [(written)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.715 0 Td [(so)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.347 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(it)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 8.03 0 Td [(will)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.992 0 Td [(accept)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.935 0 Td [(all)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(of)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -197.297 -11.956 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(standard)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.244 0 Td [(global)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.397 0 Td [(L)]TJ/F79 7.3723 Tf 2.5 1.488 Td [(A)]TJ/F79 9.9626 Tf 3.829 -1.488 Td [(T)]TJ 4.426 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.683 0 Td [(options,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.321 0 Td [(as)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(well)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.646 0 Td [(as)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(options)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -197.297 -11.956 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(standard)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.244 0 Td [(global)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.397 0 Td [(L)]TJ/F80 7.3723 Tf 2.5 1.488 Td [(A)]TJ/F80 9.9626 Tf 3.829 -1.488 Td [(T)]TJ 4.426 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.683 0 Td [(options,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.321 0 Td [(as)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(well)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.646 0 Td [(as)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(options)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -179.132 -11.955 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(speci\002c)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.926 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(underlying)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.658 0 Td [(class)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(user)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -179.132 -11.955 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(speci\002c)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.926 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(underlying)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.658 0 Td [(class)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(user)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -189.537 -11.955 Td [(has)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.771 0 Td [(chosen.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 33.245 0 Td [(F)15(or)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.179 0 Td [(e)15(xample,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.585 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(write)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.963 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(draft)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(report,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.772 0 Td [(use)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -189.537 -11.955 Td [(has)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.771 0 Td [(chosen.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 33.245 0 Td [(F)15(or)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.179 0 Td [(e)15(xample,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.585 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(write)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.963 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(draft)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(report,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.772 0 Td [(use)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -3411,14 +3411,14 @@ EMC
 /Code <</MCID 98>> BDC
 1 0 0 1 -72 -488.099 cm
 BT
-/F101 9.9626 Tf/F82 1 Tf( )Tj/F101 9.9626 Tf 72 488.099 Td [(\134documentclass[draft,)-600(report]{meta})]TJ
+/F102 9.9626 Tf/F84 1 Tf( )Tj/F102 9.9626 Tf 72 488.099 Td [(\134documentclass[draft,)-600(report]{meta})]TJ
 ET
 1 0 0 1 281.215 488.099 cm
 EMC
 /P <</MCID 99>> BDC
 1 0 0 1 -281.215 -488.099 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 281.215 488.099 Td [(.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 281.215 488.099 Td [(.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -3427,7 +3427,7 @@ EMC
 /P <</MCID 100>> BDC
 1 0 0 1 -72 -469.533 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 469.533 Td [(Options)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.042 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(ha)20(v)15(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.952 0 Td [(been)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(implemented)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 54.515 0 Td [(include:)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 469.533 Td [(Options)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.042 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(ha)20(v)15(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.952 0 Td [(been)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(implemented)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 54.515 0 Td [(include:)]TJ
 ET
 1 0 0 1 255.43 469.533 cm
 EMC
@@ -3438,7 +3438,7 @@ EMC
 /Lbl <</MCID 101>> BDC
 1 0 0 1 -67.019 -450.967 cm
 BT
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 74.491 450.967 Td [(book)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 74.491 450.967 Td [(book)]TJ
 ET
 1 0 0 1 98.022 450.967 cm
 EMC
@@ -3447,14 +3447,14 @@ EMC
 /LBody <</MCID 102>> BDC
 1 0 0 1 -103.004 -450.967 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 103.004 450.967 Td [(compile)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.589 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.08 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(L)]TJ/F79 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 103.004 450.967 Td [(compile)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.589 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.08 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(L)]TJ/F80 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ
 ET
 1 0 0 1 258.067 450.967 cm
 EMC
 /Span <</MCID 103>> BDC
 1 0 0 1 -258.067 -450.967 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 258.067 450.967 Td [(book)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 258.067 450.967 Td [(book)]TJ
 ET
 1 0 0 1 277.603 450.967 cm
 EMC
@@ -3463,10 +3463,10 @@ EMC
 0 g 0 G
 1 0 0 1 -277.603 -450.967 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 91.925 439.011 Td [(class.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.946 0 Td [(This)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(intended)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.801 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(longer)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.945 0 Td [(documents)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.659 0 Td [(and)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 91.925 439.011 Td [(class.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.946 0 Td [(This)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(intended)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.801 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(longer)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.945 0 Td [(documents)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.659 0 Td [(and)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -178.798 -11.955 Td [(allo)25(ws)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.254 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(use)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.77 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(chapters.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -178.798 -11.955 Td [(allo)25(ws)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.254 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(use)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.77 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(chapters.)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -3476,7 +3476,7 @@ EMC
 /Lbl <</MCID 105>> BDC
 1 0 0 1 -67.019 -408.49 cm
 BT
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 74.491 408.49 Td [(r)18(eport)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 74.491 408.49 Td [(r)18(eport)]TJ
 ET
 1 0 0 1 103.91 408.49 cm
 EMC
@@ -3485,14 +3485,14 @@ EMC
 /LBody <</MCID 106>> BDC
 1 0 0 1 -108.891 -408.49 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 108.891 408.49 Td [(compile)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.59 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.08 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.664 0 Td [(L)]TJ/F79 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.427 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 108.891 408.49 Td [(compile)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.59 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.08 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.664 0 Td [(L)]TJ/F80 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.427 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ
 ET
 1 0 0 1 263.954 408.49 cm
 EMC
 /Span <</MCID 107>> BDC
 1 0 0 1 -263.954 -408.49 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 263.954 408.49 Td [(r)37(eport)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 263.954 408.49 Td [(r)37(eport)]TJ
 ET
 1 0 0 1 288.671 408.49 cm
 EMC
@@ -3501,10 +3501,10 @@ EMC
 0 g 0 G
 1 0 0 1 -288.671 -408.49 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 91.925 396.535 Td [(class.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.946 0 Td [(This)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(intended)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.801 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(longer)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.945 0 Td [(documents)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.659 0 Td [(and)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 91.925 396.535 Td [(class.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.946 0 Td [(This)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(intended)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.801 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(longer)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.945 0 Td [(documents)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.659 0 Td [(and)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -178.798 -11.955 Td [(allo)25(ws)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.254 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(use)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.77 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(chapters.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -178.798 -11.955 Td [(allo)25(ws)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.254 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(use)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.77 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(chapters.)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -3514,7 +3514,7 @@ EMC
 /Lbl <</MCID 109>> BDC
 1 0 0 1 -67.019 -366.014 cm
 BT
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 74.491 366.014 Td [(article)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 74.491 366.014 Td [(article)]TJ
 ET
 1 0 0 1 104.089 366.014 cm
 EMC
@@ -3523,14 +3523,14 @@ EMC
 /LBody <</MCID 110>> BDC
 1 0 0 1 -109.071 -366.014 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 109.071 366.014 Td [(compile)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.589 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.08 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(L)]TJ/F79 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 109.071 366.014 Td [(compile)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.589 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.08 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(L)]TJ/F80 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ
 ET
 1 0 0 1 264.133 366.014 cm
 EMC
 /Span <</MCID 111>> BDC
 1 0 0 1 -264.133 -366.014 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 264.133 366.014 Td [(article)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 264.133 366.014 Td [(article)]TJ
 ET
 1 0 0 1 290.145 366.014 cm
 EMC
@@ -3539,13 +3539,13 @@ EMC
 0 g 0 G
 1 0 0 1 -290.145 -366.014 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 91.925 354.058 Td [(class.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.946 0 Td [(This)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(intended)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.801 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(shorter)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.157 0 Td [(documents)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.658 0 Td [(such)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 91.925 354.058 Td [(class.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.946 0 Td [(This)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(intended)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.801 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(shorter)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.157 0 Td [(documents)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.658 0 Td [(such)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -181.009 -11.955 Td [(as)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(journal)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.714 0 Td [(articles.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.351 0 Td [(This)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(class)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.857 0 Td [(does)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(not)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(support)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.378 0 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -181.009 -11.955 Td [(as)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(journal)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.714 0 Td [(articles.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.351 0 Td [(This)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(class)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.857 0 Td [(does)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(not)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(support)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.378 0 Td [(the)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -186.269 -11.955 Td [(use)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.771 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(chapters.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -186.269 -11.955 Td [(use)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.771 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(chapters.)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -3555,7 +3555,7 @@ EMC
 /Lbl <</MCID 113>> BDC
 1 0 0 1 -67.019 -311.582 cm
 BT
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 74.491 311.582 Td [(memoir)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 74.491 311.582 Td [(memoir)]TJ
 ET
 1 0 0 1 110.177 311.582 cm
 EMC
@@ -3564,14 +3564,14 @@ EMC
 /LBody <</MCID 114>> BDC
 1 0 0 1 -115.158 -311.582 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 115.158 311.582 Td [(compile)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.59 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.079 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(L)]TJ/F79 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 115.158 311.582 Td [(compile)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.59 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.079 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(L)]TJ/F80 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ
 ET
 1 0 0 1 270.221 311.582 cm
 EMC
 /Span <</MCID 115>> BDC
 1 0 0 1 -270.221 -311.582 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 270.221 311.582 Td [(memoir)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 270.221 311.582 Td [(memoir)]TJ
 ET
 1 0 0 1 300.885 311.582 cm
 EMC
@@ -3580,10 +3580,10 @@ EMC
 0 g 0 G
 1 0 0 1 -300.885 -311.582 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 91.925 299.627 Td [(class.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.946 0 Td [(This)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(option)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.955 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(not)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(recommended)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 58.928 0 Td [(because)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.022 0 Td [(of)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 91.925 299.627 Td [(class.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.946 0 Td [(This)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(option)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.955 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(not)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(recommended)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 58.928 0 Td [(because)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.022 0 Td [(of)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -190.414 -11.955 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(challenge)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.667 0 Td [(with)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(later)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.194 0 Td [(con)40(v)15(erting)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.553 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(rtf)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(format.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -190.414 -11.955 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(challenge)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.667 0 Td [(with)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(later)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.194 0 Td [(con)40(v)15(erting)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.553 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(rtf)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(format.)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -3593,7 +3593,7 @@ EMC
 /Lbl <</MCID 117>> BDC
 1 0 0 1 -67.019 -269.105 cm
 BT
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 74.491 269.105 Td [(draft)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 74.491 269.105 Td [(draft)]TJ
 ET
 1 0 0 1 98.56 269.105 cm
 EMC
@@ -3602,10 +3602,10 @@ EMC
 /LBody <</MCID 118>> BDC
 1 0 0 1 -103.541 -269.105 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 103.541 269.105 Td [(add)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(`draft')]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.935 0 Td [(w)10(atermark)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.991 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(all)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(pages)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.176 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(colours)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 103.541 269.105 Td [(add)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(`draft')]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.935 0 Td [(w)10(atermark)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.991 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(all)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(pages)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.176 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(colours)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -173.079 -11.955 Td [(all)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(links)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.868 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(blue.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -173.079 -11.955 Td [(all)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(links)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.868 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(blue.)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -3615,7 +3615,7 @@ EMC
 /Lbl <</MCID 119>> BDC
 1 0 0 1 -67.019 -238.584 cm
 BT
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 74.491 238.584 Td [(10pt,)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 23.8 0 Td [(12pt)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 74.491 238.584 Td [(10pt,)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 23.8 0 Td [(12pt)]TJ
 ET
 1 0 0 1 119.601 238.584 cm
 EMC
@@ -3624,10 +3624,10 @@ EMC
 /LBody <</MCID 120>> BDC
 1 0 0 1 -124.583 -238.584 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 124.583 238.584 Td [(set)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 13.558 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(font)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.541 0 Td [(size)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.982 0 Td [(accordingly)65(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 51.965 0 Td [(The)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.982 0 Td [(def)10(ault)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.057 0 Td [(is)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 124.583 238.584 Td [(set)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 13.558 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(font)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.541 0 Td [(size)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.982 0 Td [(accordingly)65(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 51.965 0 Td [(The)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.982 0 Td [(def)10(ault)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.057 0 Td [(is)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -197.408 -11.955 Td [(12)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.454 0 Td [(point.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -197.408 -11.955 Td [(12)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.454 0 Td [(point.)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -3637,7 +3637,7 @@ EMC
 /Lbl <</MCID 121>> BDC
 1 0 0 1 -67.019 -208.063 cm
 BT
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 74.491 208.063 Td [(letter)10(paper)92(,)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 51.546 0 Td [(a4paper)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 74.491 208.063 Td [(letter)10(paper)92(,)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 51.546 0 Td [(a4paper)]TJ
 ET
 1 0 0 1 163.396 208.063 cm
 EMC
@@ -3646,10 +3646,10 @@ EMC
 /LBody <</MCID 122>> BDC
 1 0 0 1 -168.378 -208.063 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 168.378 208.063 Td [(set)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 13.559 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(paper)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.617 0 Td [(size.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.071 0 Td [(The)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.982 0 Td [(def)10(ault)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.057 0 Td [(is)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 168.378 208.063 Td [(set)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 13.559 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(paper)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.617 0 Td [(size.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.071 0 Td [(The)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.982 0 Td [(def)10(ault)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.057 0 Td [(is)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -198.404 -11.955 Td [(letter)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.964 0 Td [(paper)55(.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -198.404 -11.955 Td [(letter)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.964 0 Td [(paper)55(.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -3659,7 +3659,7 @@ EMC
 /P <</MCID 123>> BDC
 1 0 0 1 -72 -177.541 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 177.541 Td [(T)80(able)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 177.541 Td [(T)80(able)]TJ
 ET
 1 0 0 1 96.378 177.541 cm
 EMC
@@ -3667,7 +3667,7 @@ EMC
 0 g 0 G
 1 0 0 1 -96.378 -177.541 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 96.378 177.541 Td [(1)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 96.378 177.541 Td [(1)]TJ
 0 g 0 G
 ET
 1 0 0 1 101.36 177.541 cm
@@ -3675,7 +3675,7 @@ EMC
 /P <</MCID 125>> BDC
 1 0 0 1 -101.36 -177.541 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 103.85 177.541 Td [(lists)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.55 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(packages)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.003 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(e)15(xplicitly)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.979 0 Td [(called)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.281 0 Td [(by)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 103.85 177.541 Td [(lists)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.55 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(packages)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.003 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(e)15(xplicitly)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.979 0 Td [(called)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.281 0 Td [(by)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -3684,17 +3684,17 @@ EMC
 /Span <</MCID 126>> BDC
 1 0 0 1 -72 -165.586 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 72 165.586 Td [(meta)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 72 165.586 Td [(meta)]TJ
 ET
 1 0 0 1 91.925 165.586 cm
 EMC
 /P <</MCID 127>> BDC
 1 0 0 1 -91.925 -165.586 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 94.416 165.586 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(order)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.512 0 Td [(the)15(y)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.496 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(called)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.281 0 Td [(in.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 13.33 0 Td [(These)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.281 0 Td [(packages)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 94.416 165.586 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(order)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.512 0 Td [(the)15(y)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.496 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(called)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.281 0 Td [(in.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 13.33 0 Td [(These)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.281 0 Td [(packages)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -170.877 -11.955 Td [(often)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.964 0 Td [(call)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(other)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.964 0 Td [(packages,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.494 0 Td [(so)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.347 0 Td [(this)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.886 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(not)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(an)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(e)15(xhausti)25(v)15(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.553 0 Td [(list.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -170.877 -11.955 Td [(often)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.964 0 Td [(call)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(other)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.964 0 Td [(packages,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.494 0 Td [(so)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.347 0 Td [(this)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.886 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(not)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(an)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(e)15(xhausti)25(v)15(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.553 0 Td [(list.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -3703,10 +3703,10 @@ EMC
 /TD <</MCID 296>> BDC
 1 0 0 1 -72 -135.065 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 135.065 Td [(The)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.982 0 Td [(meta)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(class)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(also)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.54 0 Td [(includes)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.696 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(fe)25(w)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.175 0 Td [(options)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.83 0 Td [(related)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.599 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(the)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 135.065 Td [(The)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.982 0 Td [(meta)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(class)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(also)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.54 0 Td [(includes)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.696 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(fe)25(w)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.175 0 Td [(options)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.83 0 Td [(related)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.599 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(the)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -211.694 -11.955 Td [(PDF)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.762 0 Td [(\002les)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.098 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(pd\003ate)15(x)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.441 0 Td [(produces:)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -211.694 -11.955 Td [(PDF)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.762 0 Td [(\002les)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.098 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(pd\003ate)15(x)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.441 0 Td [(produces:)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -3716,7 +3716,7 @@ EMC
 /Lbl <</MCID 297>> BDC
 1 0 0 1 -67.019 -104.544 cm
 BT
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 74.491 104.544 Td [(pd\002nterw)10(ordspaceon)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 74.491 104.544 Td [(pd\002nterw)10(ordspaceon)]TJ
 ET
 1 0 0 1 167.102 104.544 cm
 EMC
@@ -3725,10 +3725,10 @@ EMC
 /LBody <</MCID 298>> BDC
 1 0 0 1 -172.084 -104.544 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 172.084 104.544 Td [(T)45(urns)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.285 0 Td [(on)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(inter)20(-w)10(ord)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.244 0 Td [(spacing)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.926 0 Td [(in)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 172.084 104.544 Td [(T)45(urns)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.285 0 Td [(on)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(inter)20(-w)10(ord)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.244 0 Td [(spacing)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.926 0 Td [(in)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -195.067 -11.955 Td [(PDFs.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.726 0 Td [(Requires)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 37.907 0 Td [(T)70(e)15(xLi)25(v)15(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.999 0 Td [(2014.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -195.067 -11.955 Td [(PDFs.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.726 0 Td [(Requires)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 37.907 0 Td [(T)70(e)15(xLi)25(v)15(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.999 0 Td [(2014.)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -3738,7 +3738,7 @@ EMC
 /Lbl <</MCID 299>> BDC
 1 0 0 1 -67.019 -74.022 cm
 BT
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 74.491 74.022 Td [(pdfminor)10(v)10(ersion=8)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 74.491 74.022 Td [(pdfminor)10(v)10(ersion=8)]TJ
 ET
 1 0 0 1 158.843 74.022 cm
 EMC
@@ -3747,7 +3747,7 @@ EMC
 /LBody <</MCID 300>> BDC
 1 0 0 1 -163.825 -74.022 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 163.825 74.022 Td [(Sets)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.098 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(PDF)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.762 0 Td [(v)15(ersion.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 163.825 74.022 Td [(Sets)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.098 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(PDF)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.762 0 Td [(v)15(ersion.)]TJ
 0 g 0 G
 ET
 1 0 0 1 72 74.022 cm
@@ -3763,7 +3763,7 @@ EMC
 /H <</MCID 302>> BDC
 1 0 0 1 -310.981 -674.037 cm
 BT
-/F92 9.9626 Tf/F82 1 Tf( )Tj/F92 9.9626 Tf 310.981 674.037 Td [(3.2)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 23.811 0 Td [(Accessibility)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 63.68 0 Td [(suppor)-20(t)]TJ
+/F94 9.9626 Tf/F84 1 Tf( )Tj/F94 9.9626 Tf 310.981 674.037 Td [(3.2)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 23.811 0 Td [(Accessibility)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 63.68 0 Td [(suppor)-20(t)]TJ
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 g 0 G
@@ -3774,30 +3774,30 @@ EMC
 /P <</MCID 303>> BDC
 1 0 0 1 -310.981 -654.984 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 654.984 Td [(L)]TJ/F79 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.427 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.683 0 Td [(does)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(not)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(prepare)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.358 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(structured)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 42.331 0 Td [(PDF)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.762 0 Td [(document)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 654.984 Td [(L)]TJ/F80 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.427 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.683 0 Td [(does)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(not)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(prepare)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.358 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(structured)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 42.331 0 Td [(PDF)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.762 0 Td [(document)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -163.621 -11.955 Td [(directly)65(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.367 0 Td [(Instead,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 33.753 0 Td [(we)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(use)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.771 0 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -163.621 -11.955 Td [(directly)65(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.367 0 Td [(Instead,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 33.753 0 Td [(we)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(use)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.771 0 Td [(the)]TJ
 ET
 1 0 0 1 424.644 643.029 cm
 EMC
 /Span <</MCID 304>> BDC
 1 0 0 1 -424.644 -643.029 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 424.644 643.029 Td [(accessibility-meta)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 424.644 643.029 Td [(accessibility-meta)]TJ
 ET
 1 0 0 1 497.141 643.029 cm
 EMC
 /P <</MCID 305>> BDC
 1 0 0 1 -497.141 -643.029 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 499.631 643.029 Td [(package)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 499.631 643.029 Td [(package)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -188.65 -11.956 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(do)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(this)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.886 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(us.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.436 0 Td [(This)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(generates)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.109 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(tagged)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.051 0 Td [(PDF)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.762 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(passes)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -188.65 -11.956 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(do)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(this)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.886 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(us.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.436 0 Td [(This)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(generates)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.109 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(tagged)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.051 0 Td [(PDF)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.762 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(passes)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -202.598 -11.955 Td [(most)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.868 0 Td [(automated)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 43.994 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(tests.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -202.598 -11.955 Td [(most)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.868 0 Td [(automated)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 43.994 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(tests.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -3808,7 +3808,7 @@ EMC
 /H <</MCID 306>> BDC
 1 0 0 1 -310.981 -586.635 cm
 BT
-/F102 9.9626 Tf/F82 1 Tf( )Tj/F102 9.9626 Tf 310.981 586.635 Td [(3.2.1)]TJ/F82 1 Tf( )Tj/F102 9.9626 Tf 32.119 0 Td [(Alter)-25(nativ)25(e)]TJ/F82 1 Tf( )Tj/F102 9.9626 Tf 49.833 0 Td [(te)30(xt)]TJ
+/F103 9.9626 Tf/F84 1 Tf( )Tj/F103 9.9626 Tf 310.981 586.635 Td [(3.2.1)]TJ/F84 1 Tf( )Tj/F103 9.9626 Tf 32.119 0 Td [(Alter)-25(nativ)25(e)]TJ/F84 1 Tf( )Tj/F103 9.9626 Tf 49.833 0 Td [(te)30(xt)]TJ
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 g 0 G
@@ -3819,22 +3819,22 @@ EMC
 /P <</MCID 307>> BDC
 1 0 0 1 -310.981 -567.582 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 567.582 Td [(Alternati)25(v)15(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 46.914 0 Td [(te)15(xt,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.775 0 Td [(or)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(`)80(Alt)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.743 0 Td [(te)15(xt',)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.093 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(te)15(xtual)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.459 0 Td [(description)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 46.764 0 Td [(of)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 567.582 Td [(Alternati)25(v)15(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 46.914 0 Td [(te)15(xt,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.775 0 Td [(or)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(`)80(Alt)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.743 0 Td [(te)15(xt',)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.093 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(te)15(xtual)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.459 0 Td [(description)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 46.764 0 Td [(of)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -210.588 -11.955 Td [(an)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.896 0 Td [(equation,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.292 0 Td [(link)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.992 0 Td [(or)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(\002gure)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.733 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(used)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(replace)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.252 0 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -210.588 -11.955 Td [(an)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.896 0 Td [(equation,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.292 0 Td [(link)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.992 0 Td [(or)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(\002gure)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.733 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(used)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(replace)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.252 0 Td [(the)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -213.597 -11.956 Td [(visual)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.291 0 Td [(information)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 49.534 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(element.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 37.12 0 Td [(This)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(often)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.963 0 Td [(seen)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.194 0 Td [(as)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -213.597 -11.956 Td [(visual)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.291 0 Td [(information)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 49.534 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(element.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 37.12 0 Td [(This)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(often)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.963 0 Td [(seen)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.194 0 Td [(as)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -213.118 -11.955 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(te)15(xt)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.285 0 Td [(`pop-up')]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 37.35 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(PDF)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.762 0 Td [(readers.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.34 0 Td [(F)15(or)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.18 0 Td [(e)15(xample,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.585 0 Td [(passing)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -213.118 -11.955 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(te)15(xt)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.285 0 Td [(`pop-up')]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 37.35 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(PDF)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.762 0 Td [(readers.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.34 0 Td [(F)15(or)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.18 0 Td [(e)15(xample,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.585 0 Td [(passing)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -181.658 -11.955 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(pointer)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.715 0 Td [(o)15(v)15(er)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.895 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(follo)25(wing)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.986 0 Td [(readers)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.252 0 Td [(should)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.061 0 Td [(re)25(v)15(eal)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.431 0 Td [(a)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -181.658 -11.955 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(pointer)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.715 0 Td [(o)15(v)15(er)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.895 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(follo)25(wing)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.986 0 Td [(readers)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.252 0 Td [(should)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.061 0 Td [(re)25(v)15(eal)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.431 0 Td [(a)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -207.67 -11.955 Td [(pop-up:)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -207.67 -11.955 Td [(pop-up:)]TJ
 ET
 1 0 0 1 345.063 507.806 cm
 EMC
@@ -3842,7 +3842,7 @@ EMC
 0 g 0 G
 1 0 0 1 -345.063 -507.806 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 400.683 495.851 Td [(a)]TJ/F79 7.3723 Tf 4.981 4.114 Td [(2)]TJ/F8 9.9626 Tf 5.568 -4.114 Td [(+)]TJ/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 9.125 0 Td [(b)]TJ/F79 7.3723 Tf 4.981 4.114 Td [(2)]TJ/F8 9.9626 Tf/F82 1 Tf( )Tj/F8 9.9626 Tf 6.398 -4.114 Td [(=)]TJ/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 9.955 0 Td [(c)]TJ/F79 7.3723 Tf 4.423 4.114 Td [(2)]TJ/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 82.27 -4.114 Td [(\0501\051)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 400.683 495.851 Td [(a)]TJ/F80 7.3723 Tf 4.981 4.114 Td [(2)]TJ/F8 9.9626 Tf 5.568 -4.114 Td [(+)]TJ/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 9.125 0 Td [(b)]TJ/F80 7.3723 Tf 4.981 4.114 Td [(2)]TJ/F8 9.9626 Tf/F84 1 Tf( )Tj/F8 9.9626 Tf 6.398 -4.114 Td [(=)]TJ/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 9.955 0 Td [(c)]TJ/F80 7.3723 Tf 4.423 4.114 Td [(2)]TJ/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 82.27 -4.114 Td [(\0501\051)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -3852,29 +3852,29 @@ ET
 /P <</MCID 308>> BDC
 1 0 0 1 -310.981 -460.052 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 460.052 Td [(Alt)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(te)15(xt)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.285 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(added)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.281 0 Td [(after)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.742 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(PDF)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.762 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(compiled)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.571 0 Td [(using)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 460.052 Td [(Alt)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(te)15(xt)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.285 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(added)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.281 0 Td [(after)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.742 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(PDF)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.762 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(compiled)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.571 0 Td [(using)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -191.879 -11.955 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(PDF)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.762 0 Td [(editor)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.733 0 Td [(such)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(as)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(Adobe')55(s)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.696 0 Td [(Acrobat)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.58 0 Td [(Pro.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.417 0 Td [(Alterna-)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -191.879 -11.955 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(PDF)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.762 0 Td [(editor)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.733 0 Td [(such)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(as)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(Adobe')55(s)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.696 0 Td [(Acrobat)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.58 0 Td [(Pro.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.417 0 Td [(Alterna-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -174.644 -11.956 Td [(ti)25(v)15(ely)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.787 0 Td [(\226)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(probably)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 37.907 0 Td [(best)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.54 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(ensuring)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.802 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(\002nal)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -174.644 -11.956 Td [(ti)25(v)15(ely)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.787 0 Td [(\226)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(probably)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 37.907 0 Td [(best)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.54 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(ensuring)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.802 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(\002nal)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -188.591 -11.955 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(what)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.664 0 Td [(author)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.945 0 Td [(intended)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.802 0 Td [(\226)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 7.472 0 Td [(it)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 8.03 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.318 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.896 0 Td [(gen-)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -188.591 -11.955 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(what)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.664 0 Td [(author)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.945 0 Td [(intended)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.802 0 Td [(\226)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 7.472 0 Td [(it)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 8.03 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.318 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.896 0 Td [(gen-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -195.904 -11.955 Td [(erated)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.829 0 Td [(from)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(within)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.955 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(source)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.493 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.079 0 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -195.904 -11.955 Td [(erated)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.829 0 Td [(from)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(within)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.955 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(source)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.493 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.079 0 Td [(the)]TJ
 0 g 0 G
 0 g 0 G
-/F107 9.9626 Tf/F82 1 Tf( )Tj/F107 9.9626 Tf -185.662 -11.955 Td [(pdftooltip)]TJ/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 62.267 0 Td [(en)40(vironment)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 52.453 0 Td [(from)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.857 0 Td [(the)]TJ
+/F108 9.9626 Tf/F84 1 Tf( )Tj/F108 9.9626 Tf -185.662 -11.955 Td [(pdftooltip)]TJ/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 62.267 0 Td [(en)40(vironment)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 52.453 0 Td [(from)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.857 0 Td [(the)]TJ
 ET
 1 0 0 1 462.223 400.276 cm
 EMC
 /Span <</MCID 309>> BDC
 1 0 0 1 -462.223 -400.276 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 462.223 400.276 Td [(pdfcomment)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 462.223 400.276 Td [(pdfcomment)]TJ
 ET
 1 0 0 1 513.172 400.276 cm
 EMC
@@ -3883,7 +3883,7 @@ EMC
 0 g 0 G
 1 0 0 1 -513.172 -400.276 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 388.321 Td [(package.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.217 0 Td [(The)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.982 0 Td [(pre)25(vious)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.553 0 Td [(equation)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.802 0 Td [(w)10(as)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.882 0 Td [(generated)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.215 0 Td [(using)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 388.321 Td [(package.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.217 0 Td [(The)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.982 0 Td [(pre)25(vious)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.553 0 Td [(equation)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.802 0 Td [(w)10(as)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.882 0 Td [(generated)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.215 0 Td [(using)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -3892,14 +3892,14 @@ EMC
 /Code <</MCID 311>> BDC
 1 0 0 1 -310.981 -376.366 cm
 BT
-/F101 9.9626 Tf/F82 1 Tf( )Tj/F101 9.9626 Tf 310.981 376.366 Td [(\134pdftooltip{a^2+b^2=c^2}{An)-600(equation})]TJ
+/F102 9.9626 Tf/F84 1 Tf( )Tj/F102 9.9626 Tf 310.981 376.366 Td [(\134pdftooltip{a^2+b^2=c^2}{An)-600(equation})]TJ
 ET
 1 0 0 1 532.152 376.366 cm
 EMC
 /P <</MCID 312>> BDC
 1 0 0 1 -532.152 -376.366 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 532.152 376.366 Td [(.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 532.152 376.366 Td [(.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -3908,10 +3908,10 @@ EMC
 /P <</MCID 313>> BDC
 1 0 0 1 -310.981 -358.433 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 358.433 Td [(The)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.983 0 Td [(same)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.963 0 Td [(approach)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.004 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(used)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(create)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.272 0 Td [(alt)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(te)15(xt)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.285 0 Td [(for)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 358.433 Td [(The)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.983 0 Td [(same)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.963 0 Td [(approach)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.004 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(used)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(create)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.272 0 Td [(alt)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(te)15(xt)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.285 0 Td [(for)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -195.167 -11.955 Td [(images.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 33.803 0 Td [(F)15(or)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.179 0 Td [(e)15(xample,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.585 0 Td [(Figure)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -195.167 -11.955 Td [(images.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 33.803 0 Td [(F)15(or)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.179 0 Td [(e)15(xample,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.585 0 Td [(Figure)]TJ
 ET
 1 0 0 1 428.051 346.478 cm
 EMC
@@ -3919,7 +3919,7 @@ EMC
 0 g 0 G
 1 0 0 1 -428.051 -346.478 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 428.051 346.478 Td [(1)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 428.051 346.478 Td [(1)]TJ
 0 g 0 G
 ET
 1 0 0 1 433.033 346.478 cm
@@ -3927,10 +3927,10 @@ EMC
 /P <</MCID 315>> BDC
 1 0 0 1 -433.033 -346.478 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 435.523 346.478 Td [(has)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.771 0 Td [(been)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(labeled)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.262 0 Td [(with)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(a)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 435.523 346.478 Td [(has)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.771 0 Td [(been)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(labeled)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.262 0 Td [(with)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(a)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -213.079 -11.955 Td [(tool)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.993 0 Td [(tip.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -213.079 -11.955 Td [(tool)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.993 0 Td [(tip.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -3938,22 +3938,22 @@ ET
 /P <</MCID 332>> BDC
 1 0 0 1 -310.981 -316.59 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 316.59 Td [(Note)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(the)]TJ/F101 9.9626 Tf/F82 1 Tf( )Tj/F101 9.9626 Tf 14.665 0 Td [(subfig)]TJ/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 38.356 0 Td [(and)]TJ/F101 9.9626 Tf/F82 1 Tf( )Tj/F101 9.9626 Tf 16.877 0 Td [(subfigure)]TJ/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 56.289 0 Td [(packages)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.003 0 Td [(are)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 316.59 Td [(Note)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(the)]TJ/F102 9.9626 Tf/F84 1 Tf( )Tj/F102 9.9626 Tf 14.665 0 Td [(subfig)]TJ/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 38.356 0 Td [(and)]TJ/F102 9.9626 Tf/F84 1 Tf( )Tj/F102 9.9626 Tf 16.877 0 Td [(subfigure)]TJ/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 56.289 0 Td [(packages)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.003 0 Td [(are)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -204.482 -11.955 Td [(deprecated)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.639 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(so)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.348 0 Td [(sub\002gures)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 43.446 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(implemented)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 54.515 0 Td [(using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.08 0 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -204.482 -11.955 Td [(deprecated)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.639 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(so)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.348 0 Td [(sub\002gures)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 43.446 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(implemented)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 54.515 0 Td [(using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.08 0 Td [(the)]TJ
 0 g 0 G
 0 g 0 G
-/F101 9.9626 Tf/F82 1 Tf( )Tj/F101 9.9626 Tf -210.559 -11.956 Td [(subcaption)]TJ/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 62.267 0 Td [(package.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.216 0 Td [(The)]TJ/F101 9.9626 Tf/F82 1 Tf( )Tj/F101 9.9626 Tf 17.983 0 Td [(subcaption)]TJ/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 62.266 0 Td [(package)]TJ
+/F102 9.9626 Tf/F84 1 Tf( )Tj/F102 9.9626 Tf -210.559 -11.956 Td [(subcaption)]TJ/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 62.267 0 Td [(package.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.216 0 Td [(The)]TJ/F102 9.9626 Tf/F84 1 Tf( )Tj/F102 9.9626 Tf 17.983 0 Td [(subcaption)]TJ/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 62.266 0 Td [(package)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -180.732 -11.955 Td [(appears)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.916 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(most)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.868 0 Td [(frequently)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 43.437 0 Td [(maintained)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 46.764 0 Td [(package)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -180.732 -11.955 Td [(appears)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.916 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(most)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.868 0 Td [(frequently)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 43.437 0 Td [(maintained)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 46.764 0 Td [(package)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -181.787 -11.955 Td [(at)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(this)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.886 0 Td [(time,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.695 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(contains)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.696 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(same)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.963 0 Td [(functionality)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 53.409 0 Td [(as)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -181.787 -11.955 Td [(at)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(this)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.886 0 Td [(time,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.695 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(contains)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.696 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(same)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.963 0 Td [(functionality)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 53.409 0 Td [(as)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(the)]TJ
 0 g 0 G
 0 g 0 G
-/F101 9.9626 Tf/F82 1 Tf( )Tj/F101 9.9626 Tf -203.664 -11.955 Td [(subfig)]TJ/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 38.356 0 Td [(and)]TJ/F101 9.9626 Tf/F82 1 Tf( )Tj/F101 9.9626 Tf 16.877 0 Td [(subfigure)]TJ/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 56.289 0 Td [(packages.)]TJ
+/F102 9.9626 Tf/F84 1 Tf( )Tj/F102 9.9626 Tf -203.664 -11.955 Td [(subfig)]TJ/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 38.356 0 Td [(and)]TJ/F102 9.9626 Tf/F84 1 Tf( )Tj/F102 9.9626 Tf 16.877 0 Td [(subfigure)]TJ/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 56.289 0 Td [(packages.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -3962,44 +3962,44 @@ EMC
 /P <</MCID 333>> BDC
 1 0 0 1 -310.981 -238.881 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 238.881 Td [(The)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 238.881 Td [(The)]TJ
 ET
 1 0 0 1 328.964 238.881 cm
 EMC
 /Span <</MCID 334>> BDC
 1 0 0 1 -328.964 -238.881 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 328.964 238.881 Td [(accessibility)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 328.964 238.881 Td [(accessibility)]TJ
 ET
 1 0 0 1 378.218 238.881 cm
 EMC
 /P <</MCID 335>> BDC
 1 0 0 1 -378.218 -238.881 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 380.709 238.881 Td [(package)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.128 0 Td [(includes)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.696 0 Td [(an)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 380.709 238.881 Td [(package)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.128 0 Td [(includes)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.696 0 Td [(an)]TJ
 ET
 1 0 0 1 463.428 238.881 cm
 EMC
 /Code <</MCID 336>> BDC
 1 0 0 1 -463.428 -238.881 cm
 BT
-/F101 9.9626 Tf/F82 1 Tf( )Tj/F101 9.9626 Tf 463.428 238.881 Td [(\134alt{})]TJ
+/F102 9.9626 Tf/F84 1 Tf( )Tj/F102 9.9626 Tf 463.428 238.881 Td [(\134alt{})]TJ
 ET
 1 0 0 1 499.293 238.881 cm
 EMC
 /P <</MCID 337>> BDC
 1 0 0 1 -499.293 -238.881 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 501.784 238.881 Td [(en)40(viron-)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 501.784 238.881 Td [(en)40(viron-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -190.803 -11.955 Td [(ment)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.416 0 Td [(which)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.839 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(intended)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.801 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(create)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.271 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(tool)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.992 0 Td [(tip.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.1 0 Td [(Although)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.129 0 Td [(it)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -190.803 -11.955 Td [(ment)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.416 0 Td [(which)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.839 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(intended)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.801 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(create)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.271 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(tool)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.992 0 Td [(tip.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.1 0 Td [(Although)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.129 0 Td [(it)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -212.84 -11.955 Td [(has)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.771 0 Td [(been)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(included)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.802 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(source)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.493 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(ne)15(xt)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.497 0 Td [(equation,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.292 0 Td [(it)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -212.84 -11.955 Td [(has)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.771 0 Td [(been)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(included)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.802 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(source)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.493 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(ne)15(xt)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.497 0 Td [(equation,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.292 0 Td [(it)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -211.515 -11.955 Td [(does)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(not)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(currently)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.455 0 Td [(w)10(ork.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -211.515 -11.955 Td [(does)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(not)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(currently)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.455 0 Td [(w)10(ork.)]TJ
 ET
 1 0 0 1 411.364 203.016 cm
 EMC
@@ -4007,7 +4007,7 @@ EMC
 0 g 0 G
 1 0 0 1 -411.364 -203.016 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 400.683 181.209 Td [(a)]TJ/F79 7.3723 Tf 4.981 4.114 Td [(2)]TJ/F8 9.9626 Tf 5.568 -4.114 Td [(+)]TJ/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 9.125 0 Td [(b)]TJ/F79 7.3723 Tf 4.981 4.114 Td [(2)]TJ/F8 9.9626 Tf/F82 1 Tf( )Tj/F8 9.9626 Tf 6.398 -4.114 Td [(=)]TJ/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 9.955 0 Td [(c)]TJ/F79 7.3723 Tf 4.423 4.114 Td [(2)]TJ/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 82.27 -4.114 Td [(\0502\051)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 400.683 181.209 Td [(a)]TJ/F80 7.3723 Tf 4.981 4.114 Td [(2)]TJ/F8 9.9626 Tf 5.568 -4.114 Td [(+)]TJ/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 9.125 0 Td [(b)]TJ/F80 7.3723 Tf 4.981 4.114 Td [(2)]TJ/F8 9.9626 Tf/F84 1 Tf( )Tj/F8 9.9626 Tf 6.398 -4.114 Td [(=)]TJ/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 9.955 0 Td [(c)]TJ/F80 7.3723 Tf 4.423 4.114 Td [(2)]TJ/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 82.27 -4.114 Td [(\0502\051)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -4018,7 +4018,7 @@ ET
 /H <</MCID 338>> BDC
 1 0 0 1 -310.981 -126.919 cm
 BT
-/F102 9.9626 Tf/F82 1 Tf( )Tj/F102 9.9626 Tf 310.981 126.919 Td [(3.2.2)]TJ/F82 1 Tf( )Tj/F102 9.9626 Tf 32.119 0 Td [(Prob)20(lems)]TJ/F82 1 Tf( )Tj/F102 9.9626 Tf 44.643 0 Td [(with)]TJ/F82 1 Tf( )Tj/F102 9.9626 Tf 20.482 0 Td [(embedded)]TJ/F82 1 Tf( )Tj/F102 9.9626 Tf 49.843 0 Td [(f)30(onts)]TJ
+/F103 9.9626 Tf/F84 1 Tf( )Tj/F103 9.9626 Tf 310.981 126.919 Td [(3.2.2)]TJ/F84 1 Tf( )Tj/F103 9.9626 Tf 32.119 0 Td [(Prob)20(lems)]TJ/F84 1 Tf( )Tj/F103 9.9626 Tf 44.643 0 Td [(with)]TJ/F84 1 Tf( )Tj/F103 9.9626 Tf 20.482 0 Td [(embedded)]TJ/F84 1 Tf( )Tj/F103 9.9626 Tf 49.843 0 Td [(f)30(onts)]TJ
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 g 0 G
@@ -4029,16 +4029,16 @@ EMC
 /P <</MCID 339>> BDC
 1 0 0 1 -310.981 -107.865 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 107.865 Td [(One)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.089 0 Td [(requirement)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 50.629 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(passing)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.378 0 Td [(automated)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 43.994 0 Td [(tests)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(acces-)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 107.865 Td [(One)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.089 0 Td [(requirement)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 50.629 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(passing)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.378 0 Td [(automated)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 43.994 0 Td [(tests)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(acces-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -191.191 -11.955 Td [(sibility)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.176 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(fonts)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.416 0 Td [(must)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.868 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(embedded)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 43.437 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(\002nal)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -191.191 -11.955 Td [(sibility)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.176 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(fonts)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.416 0 Td [(must)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.868 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(embedded)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 43.437 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(\002nal)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -195.933 -11.955 Td [(PDF)80(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.456 0 Td [(Y)110(ou)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.55 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(check)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.723 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(PDF)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.762 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(embedded)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 43.437 0 Td [(fonts)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.416 0 Td [(using)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -195.933 -11.955 Td [(PDF)80(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.456 0 Td [(Y)110(ou)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.55 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(check)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.723 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(PDF)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.762 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(embedded)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 43.437 0 Td [(fonts)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.416 0 Td [(using)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -198.435 -11.955 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(PDF)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.762 0 Td [(vie)25(wer)55(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.89 0 Td [(F)15(or)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.18 0 Td [(e)15(xample,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.585 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(Adobe)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.051 0 Td [(Acrobat)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.58 0 Td [(Reader)40(,)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -198.435 -11.955 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(PDF)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.762 0 Td [(vie)25(wer)55(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.89 0 Td [(F)15(or)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.18 0 Td [(e)15(xample,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.585 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(Adobe)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.051 0 Td [(Acrobat)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.58 0 Td [(Reader)40(,)]TJ
 0 g 0 G
 ET
 1 0 0 1 310.981 72 cm
@@ -4049,7 +4049,7 @@ EMC
 /Artifact <</Type /Pagination>> BDC
 1 0 0 1 -72 -42.112 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 303.509 42.112 Td [(3)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 303.509 42.112 Td [(3)]TJ
 ET
 1 0 0 1 540 42.112 cm
 EMC
@@ -4057,24 +4057,24 @@ EMC
 
 endstream
 endobj
-245 0 obj
+247 0 obj
 <<
 /Type /Page
-/Contents 396 0 R
-/Resources 395 0 R
+/Contents 398 0 R
+/Resources 397 0 R
 /MediaBox [0 0 612 792]
-/Parent 152 0 R
-/Annots [ 360 0 R 277 0 R 366 0 R ]
+/Parent 154 0 R
+/Annots [ 362 0 R 279 0 R 368 0 R ]
 >>
 endobj
-360 0 obj
+362 0 obj
 <<
 /Type /Annot
 /Subtype /Widget /TU (\376\377\000A\000n\000\040\000e\000q\000u\000a\000t\000i\000o\000n) /T (tooltip zref@0) /C [ ] /FT/Btn /F 768 /Ff 65536 /H/N /BS << /W 0 >> 
 /Rect [400.683 495.039 450.299 504.399]
 >>
 endobj
-277 0 obj
+279 0 obj
 <<
 /Type /Annot
 /Subtype /Link
@@ -4083,7 +4083,7 @@ endobj
 /A << /S /GoTo /D (table.caption.2) >>
 >>
 endobj
-366 0 obj
+368 0 obj
 <<
 /Type /Annot
 /Subtype /Link
@@ -4092,44 +4092,44 @@ endobj
 /A << /S /GoTo /D (figure.caption.3) >>
 >>
 endobj
-397 0 obj
+399 0 obj
 <<
-/D [245 0 R /XYZ 71 718.907 null]
+/D [247 0 R /XYZ 71 718.907 null]
 >>
 endobj
 23 0 obj
 <<
-/D [245 0 R /XYZ 310.981 684 null]
+/D [247 0 R /XYZ 310.981 684 null]
 >>
 endobj
 27 0 obj
 <<
-/D [245 0 R /XYZ 310.981 604.468 null]
+/D [247 0 R /XYZ 310.981 604.468 null]
 >>
 endobj
-400 0 obj
+402 0 obj
 <<
-/D [245 0 R /XYZ 400.683 507.806 null]
+/D [247 0 R /XYZ 400.683 507.806 null]
 >>
 endobj
-403 0 obj
+405 0 obj
 <<
-/D [245 0 R /XYZ 400.683 193.164 null]
+/D [247 0 R /XYZ 400.683 193.164 null]
 >>
 endobj
 31 0 obj
 <<
-/D [245 0 R /XYZ 310.981 144.852 null]
+/D [247 0 R /XYZ 310.981 144.852 null]
 >>
 endobj
-395 0 obj
+397 0 obj
 <<
  /ColorSpace 3 0 R /Pattern 2 0 R /ExtGState 1 0 R 
-/Font << /F79 141 0 R /F82 145 0 R /F85 146 0 R /F91 235 0 R /F101 398 0 R /F86 147 0 R /F92 243 0 R /F102 399 0 R /F8 401 0 R /F107 402 0 R >>
+/Font << /F80 143 0 R /F84 147 0 R /F87 148 0 R /F93 237 0 R /F102 400 0 R /F88 149 0 R /F94 245 0 R /F103 401 0 R /F8 403 0 R /F108 404 0 R >>
 /ProcSet [ /PDF /Text ]
 >>
 endobj
-406 0 obj
+408 0 obj
 <<
 /Length 21058     
 >>
@@ -4143,21 +4143,21 @@ EMC
 /Caption <</MCID 128>> BDC
 1 0 0 1 -72 -614.683 cm
 BT
-/F81 8.9664 Tf/F82 1 Tf( )Tj/F81 8.9664 Tf 175.655 607.012 Td [(T)80(ab)10(le)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf 25.106 0 Td [(1.)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf 10.562 0 Td [(P)30(ac)20(ka)10(g)-10(es)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf 43.415 0 Td [(e)15(xplicitl)15(y)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf 40.599 0 Td [(loaded)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf 31.391 0 Td [(b)20(y)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf 12.777 0 Td [(the)]TJ
+/F83 8.9664 Tf/F84 1 Tf( )Tj/F83 8.9664 Tf 175.655 607.012 Td [(T)80(ab)10(le)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf 25.106 0 Td [(1.)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf 10.562 0 Td [(P)30(ac)20(ka)10(g)-10(es)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf 43.415 0 Td [(e)15(xplicitl)15(y)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf 40.599 0 Td [(loaded)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf 31.391 0 Td [(b)20(y)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf 12.777 0 Td [(the)]TJ
 ET
 1 0 0 1 355.447 607.012 cm
 EMC
 /Span <</MCID 131>> BDC
 1 0 0 1 -355.447 -607.012 cm
 BT
-/F92 8.9664 Tf/F82 1 Tf( )Tj/F92 8.9664 Tf 355.447 607.012 Td [(meta)]TJ
+/F94 8.9664 Tf/F84 1 Tf( )Tj/F94 8.9664 Tf 355.447 607.012 Td [(meta)]TJ
 ET
 1 0 0 1 376.621 607.012 cm
 EMC
 /Caption <</MCID 132>> BDC
 1 0 0 1 -376.621 -607.012 cm
 BT
-/F81 8.9664 Tf/F82 1 Tf( )Tj/F81 8.9664 Tf 379.113 607.012 Td [(c)20(lass.)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf 27.831 0 Td [(Unless)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf -231.695 -10.959 Td [(otherwise)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf 44.347 0 Td [(stated,)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf 31.391 0 Td [(pac)20(ka)10(g)-10(es)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf 43.182 0 Td [(are)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf 15.951 0 Td [(not)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf 16.435 0 Td [(suppor)-20(ted)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf 46.508 0 Td [(b)20(y)]TJ/F107 8.9664 Tf/F82 1 Tf( )Tj/F107 8.9664 Tf 12.777 0 Td [(latex2rtf)]TJ/F81 8.9664 Tf/F82 1 Tf( )Tj/F81 8.9664 Tf 48.418 0 Td [(.)]TJ
+/F83 8.9664 Tf/F84 1 Tf( )Tj/F83 8.9664 Tf 379.113 607.012 Td [(c)20(lass.)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf 27.831 0 Td [(Unless)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf -231.695 -10.959 Td [(otherwise)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf 44.347 0 Td [(stated,)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf 31.391 0 Td [(pac)20(ka)10(g)-10(es)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf 43.182 0 Td [(are)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf 15.951 0 Td [(not)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf 16.435 0 Td [(suppor)-20(ted)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf 46.508 0 Td [(b)20(y)]TJ/F108 8.9664 Tf/F84 1 Tf( )Tj/F108 8.9664 Tf 12.777 0 Td [(latex2rtf)]TJ/F83 8.9664 Tf/F84 1 Tf( )Tj/F83 8.9664 Tf 48.418 0 Td [(.)]TJ
 ET
 1 0 0 1 72 582.803 cm
 EMC
@@ -4177,35 +4177,35 @@ EMC
 /P <</MCID 134>> BDC
 1 0 0 1 -77.978 -570.849 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 570.849 Td [(P)15(ackages)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 570.849 Td [(P)15(ackages)]TJ
 ET
 1 0 0 1 148.433 570.849 cm
 EMC
 /P <</MCID 135>> BDC
 1 0 0 1 -148.433 -570.849 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 148.433 570.849 Td [(options)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 148.433 570.849 Td [(options)]TJ
 ET
 1 0 0 1 207.191 570.849 cm
 EMC
 /P <</MCID 136>> BDC
 1 0 0 1 -207.191 -570.849 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 207.191 570.849 Td [(functionality)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 207.191 570.849 Td [(functionality)]TJ
 ET
 1 0 0 1 406.343 570.849 cm
 EMC
 /P <</MCID 137>> BDC
 1 0 0 1 -406.343 -570.849 cm
 BT
-/F101 9.9626 Tf/F82 1 Tf( )Tj/F101 9.9626 Tf 406.343 570.849 Td [(latex2rtf)]TJ/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 0 -11.955 Td [(support)]TJ
+/F102 9.9626 Tf/F84 1 Tf( )Tj/F102 9.9626 Tf 406.343 570.849 Td [(latex2rtf)]TJ/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 0 -11.955 Td [(support)]TJ
 ET
 1 0 0 1 465.101 570.849 cm
 EMC
 /P <</MCID 138>> BDC
 1 0 0 1 -465.101 -570.849 cm
 BT
-/F101 9.9626 Tf/F82 1 Tf( )Tj/F101 9.9626 Tf 465.101 570.849 Td [(latex2rtf)]TJ/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 0 -11.955 Td [(w)10(orkaround)]TJ
+/F102 9.9626 Tf/F84 1 Tf( )Tj/F102 9.9626 Tf 465.101 570.849 Td [(latex2rtf)]TJ/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 0 -11.955 Td [(w)10(orkaround)]TJ
 ET
 1 0 0 1 513.141 558.894 cm
 EMC
@@ -4223,7 +4223,7 @@ EMC
 /TD <</MCID 140>> BDC
 1 0 0 1 -77.978 -541.937 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 541.937 Td [(nag)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 541.937 Td [(nag)]TJ
 ET
 1 0 0 1 148.433 541.937 cm
 EMC
@@ -4233,7 +4233,7 @@ EMC
 /TD <</MCID 142>> BDC
 1 0 0 1 -207.191 -541.937 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 207.191 541.937 Td [(checks)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.599 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(packages)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.003 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(up)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(date)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.088 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(looks)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf -159.351 -11.955 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(bad)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(habits)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.292 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(L)]TJ/F79 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(code.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 207.191 541.937 Td [(checks)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.599 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(packages)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.003 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(up)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(date)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.088 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(looks)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf -159.351 -11.955 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(bad)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(habits)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.292 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(L)]TJ/F80 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(code.)]TJ
 ET
 1 0 0 1 406.343 541.937 cm
 EMC
@@ -4248,7 +4248,7 @@ EMC
 /TD <</MCID 146>> BDC
 1 0 0 1 -77.978 -518.026 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 518.026 Td [(geometry)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 518.026 Td [(geometry)]TJ
 ET
 1 0 0 1 148.433 518.026 cm
 EMC
@@ -4258,14 +4258,14 @@ EMC
 /TD <</MCID 148>> BDC
 1 0 0 1 -207.191 -518.026 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 207.191 518.026 Td [(sets)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(page)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(size)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.982 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(mar)18(gins)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 207.191 518.026 Td [(sets)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(page)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(size)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.982 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(mar)18(gins)]TJ
 ET
 1 0 0 1 406.343 518.026 cm
 EMC
 /TD <</MCID 149>> BDC
 1 0 0 1 -406.343 -518.026 cm
 BT
-/F66 9.9626 Tf/F82 1 Tf( )Tj/F66 9.9626 Tf 406.343 518.026 Td [(X)]TJ
+/F67 9.9626 Tf/F84 1 Tf( )Tj/F67 9.9626 Tf 406.343 518.026 Td [(X)]TJ
 ET
 1 0 0 1 465.101 518.026 cm
 EMC
@@ -4277,7 +4277,7 @@ EMC
 /TD <</MCID 152>> BDC
 1 0 0 1 -77.978 -506.071 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 506.071 Td [(mathptmx)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 506.071 Td [(mathptmx)]TJ
 ET
 1 0 0 1 148.433 506.071 cm
 EMC
@@ -4287,7 +4287,7 @@ EMC
 /TD <</MCID 154>> BDC
 1 0 0 1 -207.191 -506.071 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 207.191 506.071 Td [(changes)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.58 0 Td [(fonts)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 207.191 506.071 Td [(changes)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.58 0 Td [(fonts)]TJ
 ET
 1 0 0 1 406.343 506.071 cm
 EMC
@@ -4302,7 +4302,7 @@ EMC
 /TD <</MCID 158>> BDC
 1 0 0 1 -77.978 -494.116 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 494.116 Td [(helv)15(et)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 494.116 Td [(helv)15(et)]TJ
 ET
 1 0 0 1 148.433 494.116 cm
 EMC
@@ -4312,7 +4312,7 @@ EMC
 /TD <</MCID 160>> BDC
 1 0 0 1 -207.191 -494.116 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 207.191 494.116 Td [(changes)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.58 0 Td [(fonts)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 207.191 494.116 Td [(changes)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.58 0 Td [(fonts)]TJ
 ET
 1 0 0 1 406.343 494.116 cm
 EMC
@@ -4327,7 +4327,7 @@ EMC
 /TD <</MCID 164>> BDC
 1 0 0 1 -77.978 -482.161 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 482.161 Td [(courier)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 482.161 Td [(courier)]TJ
 ET
 1 0 0 1 148.433 482.161 cm
 EMC
@@ -4337,7 +4337,7 @@ EMC
 /TD <</MCID 166>> BDC
 1 0 0 1 -207.191 -482.161 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 207.191 482.161 Td [(changes)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.58 0 Td [(fonts)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 207.191 482.161 Td [(changes)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.58 0 Td [(fonts)]TJ
 ET
 1 0 0 1 406.343 482.161 cm
 EMC
@@ -4352,7 +4352,7 @@ EMC
 /TD <</MCID 170>> BDC
 1 0 0 1 -77.978 -470.206 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 470.206 Td [(amsfonts,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 0 -11.955 Td [(amssymb)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 470.206 Td [(amsfonts,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 0 -11.955 Td [(amssymb)]TJ
 ET
 1 0 0 1 148.433 470.206 cm
 EMC
@@ -4362,7 +4362,7 @@ EMC
 /TD <</MCID 172>> BDC
 1 0 0 1 -207.191 -470.206 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 207.191 470.206 Td [(supplies)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.148 0 Td [(fonts)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.415 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.654 0 Td [(useful)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.84 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(mathematics)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 207.191 470.206 Td [(supplies)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.148 0 Td [(fonts)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.415 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.654 0 Td [(useful)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.84 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(mathematics)]TJ
 ET
 1 0 0 1 406.343 470.206 cm
 EMC
@@ -4377,7 +4377,7 @@ EMC
 /TD <</MCID 176>> BDC
 1 0 0 1 -77.978 -446.295 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 446.295 Td [(booktabs)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 446.295 Td [(booktabs)]TJ
 ET
 1 0 0 1 148.433 446.295 cm
 EMC
@@ -4398,7 +4398,7 @@ EMC
 /TD <</MCID 182>> BDC
 1 0 0 1 -77.978 -434.34 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 434.34 Td [(graphicx)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 434.34 Td [(graphicx)]TJ
 ET
 1 0 0 1 148.433 434.34 cm
 EMC
@@ -4408,21 +4408,21 @@ EMC
 /TD <</MCID 184>> BDC
 1 0 0 1 -207.191 -434.34 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 207.191 434.34 Td [(graphics)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.244 0 Td [(handling,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.85 0 Td [(including)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 207.191 434.34 Td [(graphics)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.244 0 Td [(handling,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.85 0 Td [(including)]TJ
 ET
 1 0 0 1 323.414 434.34 cm
 EMC
 /Span <</MCID 185>> BDC
 1 0 0 1 -323.414 -434.34 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 323.414 434.34 Td [(.eps)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 323.414 434.34 Td [(.eps)]TJ
 ET
 1 0 0 1 339.185 434.34 cm
 EMC
 /TD <</MCID 186>> BDC
 1 0 0 1 -339.185 -434.34 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 341.675 434.34 Td [(\002gures)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.609 0 Td [(\050see)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf -164.093 -11.955 Td [(Section)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 341.675 434.34 Td [(\002gures)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.609 0 Td [(\050see)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf -164.093 -11.955 Td [(Section)]TJ
 ET
 1 0 0 1 239.569 422.385 cm
 EMC
@@ -4430,7 +4430,7 @@ EMC
 0 g 0 G
 1 0 0 1 -239.569 -422.385 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 239.569 422.385 Td [(3.2.1)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 239.569 422.385 Td [(3.2.1)]TJ
 0 g 0 G
 ET
 1 0 0 1 259.494 422.385 cm
@@ -4438,14 +4438,14 @@ EMC
 /TD <</MCID 188>> BDC
 1 0 0 1 -259.494 -422.385 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 259.494 422.385 Td [(\051)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 259.494 422.385 Td [(\051)]TJ
 ET
 1 0 0 1 406.343 434.34 cm
 EMC
 /TD <</MCID 189>> BDC
 1 0 0 1 -406.343 -434.34 cm
 BT
-/F66 9.9626 Tf/F82 1 Tf( )Tj/F66 9.9626 Tf 406.343 434.34 Td [(X)]TJ
+/F67 9.9626 Tf/F84 1 Tf( )Tj/F67 9.9626 Tf 406.343 434.34 Td [(X)]TJ
 ET
 1 0 0 1 465.101 434.34 cm
 EMC
@@ -4457,70 +4457,70 @@ EMC
 /TD <</MCID 192>> BDC
 1 0 0 1 -77.978 -410.43 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 410.43 Td [(natbib)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 410.43 Td [(natbib)]TJ
 ET
 1 0 0 1 148.433 410.43 cm
 EMC
 /TD <</MCID 193>> BDC
 1 0 0 1 -148.433 -410.43 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 148.433 410.43 Td [(sort)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 148.433 410.43 Td [(sort)]TJ
 ET
 1 0 0 1 207.191 410.43 cm
 EMC
 /TD <</MCID 194>> BDC
 1 0 0 1 -207.191 -410.43 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 207.191 410.43 Td [(handles)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.926 0 Td [(citations)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.253 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(allo)25(ws)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.254 0 Td [(the)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 207.191 410.43 Td [(handles)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.926 0 Td [(citations)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.253 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(allo)25(ws)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.254 0 Td [(the)]TJ
 ET
 1 0 0 1 336.166 410.43 cm
 EMC
 /Code <</MCID 195>> BDC
 1 0 0 1 -336.166 -410.43 cm
 BT
-/F101 9.9626 Tf/F82 1 Tf( )Tj/F101 9.9626 Tf 336.166 410.43 Td [(\134cite)]TJ
+/F102 9.9626 Tf/F84 1 Tf( )Tj/F102 9.9626 Tf 336.166 410.43 Td [(\134cite)]TJ
 ET
 1 0 0 1 366.053 410.43 cm
 EMC
 /TD <</MCID 196>> BDC
 1 0 0 1 -366.053 -410.43 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 366.053 410.43 Td [(,)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 366.053 410.43 Td [(,)]TJ
 ET
 1 0 0 1 207.191 398.475 cm
 EMC
 /Code <</MCID 197>> BDC
 1 0 0 1 -207.191 -398.475 cm
 BT
-/F101 9.9626 Tf/F82 1 Tf( )Tj/F101 9.9626 Tf 207.191 398.475 Td [(\134citep)]TJ
+/F102 9.9626 Tf/F84 1 Tf( )Tj/F102 9.9626 Tf 207.191 398.475 Td [(\134citep)]TJ
 ET
 1 0 0 1 243.056 398.475 cm
 EMC
 /TD <</MCID 198>> BDC
 1 0 0 1 -243.056 -398.475 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 245.547 398.475 Td [(and)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 245.547 398.475 Td [(and)]TJ
 ET
 1 0 0 1 262.424 398.475 cm
 EMC
 /Code <</MCID 199>> BDC
 1 0 0 1 -262.424 -398.475 cm
 BT
-/F101 9.9626 Tf/F82 1 Tf( )Tj/F101 9.9626 Tf 262.424 398.475 Td [(\134citet)]TJ
+/F102 9.9626 Tf/F84 1 Tf( )Tj/F102 9.9626 Tf 262.424 398.475 Td [(\134citet)]TJ
 ET
 1 0 0 1 298.289 398.475 cm
 EMC
 /TD <</MCID 200>> BDC
 1 0 0 1 -298.289 -398.475 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 300.78 398.475 Td [(citation)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.378 0 Td [(commands.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 300.78 398.475 Td [(citation)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.378 0 Td [(commands.)]TJ
 ET
 1 0 0 1 406.343 410.43 cm
 EMC
 /TD <</MCID 201>> BDC
 1 0 0 1 -406.343 -410.43 cm
 BT
-/F66 9.9626 Tf/F82 1 Tf( )Tj/F66 9.9626 Tf 406.343 410.43 Td [(X)]TJ
+/F67 9.9626 Tf/F84 1 Tf( )Tj/F67 9.9626 Tf 406.343 410.43 Td [(X)]TJ
 ET
 1 0 0 1 465.101 410.43 cm
 EMC
@@ -4532,14 +4532,14 @@ EMC
 /TD <</MCID 204>> BDC
 1 0 0 1 -77.978 -386.52 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 386.52 Td [(fontenc)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 386.52 Td [(fontenc)]TJ
 ET
 1 0 0 1 148.433 386.52 cm
 EMC
 /TD <</MCID 205>> BDC
 1 0 0 1 -148.433 -386.52 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 148.433 386.52 Td [(T1)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 148.433 386.52 Td [(T1)]TJ
 ET
 1 0 0 1 207.191 386.52 cm
 EMC
@@ -4557,7 +4557,7 @@ EMC
 /TD <</MCID 210>> BDC
 1 0 0 1 -77.978 -374.564 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 374.564 Td [(xcolor)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 374.564 Td [(xcolor)]TJ
 ET
 1 0 0 1 148.433 374.564 cm
 EMC
@@ -4578,14 +4578,14 @@ EMC
 /TD <</MCID 216>> BDC
 1 0 0 1 -77.978 -362.609 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 362.609 Td [(babel)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 362.609 Td [(babel)]TJ
 ET
 1 0 0 1 148.433 362.609 cm
 EMC
 /TD <</MCID 217>> BDC
 1 0 0 1 -148.433 -362.609 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 148.433 362.609 Td [(english)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 148.433 362.609 Td [(english)]TJ
 ET
 1 0 0 1 207.191 362.609 cm
 EMC
@@ -4603,7 +4603,7 @@ EMC
 /TD <</MCID 222>> BDC
 1 0 0 1 -77.978 -350.654 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 350.654 Td [(subcaption)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 350.654 Td [(subcaption)]TJ
 ET
 1 0 0 1 148.433 350.654 cm
 EMC
@@ -4613,14 +4613,14 @@ EMC
 /TD <</MCID 224>> BDC
 1 0 0 1 -207.191 -350.654 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 207.191 350.654 Td [(pro)15(vides)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.652 0 Td [(the)]TJ/F101 9.9626 Tf/F82 1 Tf( )Tj/F101 9.9626 Tf 14.665 0 Td [(subfigure)]TJ/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 56.289 0 Td [(en)40(vironment)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 52.453 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf -160.059 -11.955 Td [(produce)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.58 0 Td [(sub)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.329 0 Td [(\002gures)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 207.191 350.654 Td [(pro)15(vides)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.652 0 Td [(the)]TJ/F102 9.9626 Tf/F84 1 Tf( )Tj/F102 9.9626 Tf 14.665 0 Td [(subfigure)]TJ/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 56.289 0 Td [(en)40(vironment)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 52.453 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf -160.059 -11.955 Td [(produce)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.58 0 Td [(sub)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.329 0 Td [(\002gures)]TJ
 ET
 1 0 0 1 406.343 350.654 cm
 EMC
 /TD <</MCID 225>> BDC
 1 0 0 1 -406.343 -350.654 cm
 BT
-/F66 9.9626 Tf/F82 1 Tf( )Tj/F66 9.9626 Tf 406.343 350.654 Td [(X)]TJ
+/F67 9.9626 Tf/F84 1 Tf( )Tj/F67 9.9626 Tf 406.343 350.654 Td [(X)]TJ
 ET
 1 0 0 1 465.101 350.654 cm
 EMC
@@ -4632,7 +4632,7 @@ EMC
 /TD <</MCID 228>> BDC
 1 0 0 1 -77.978 -326.744 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 326.744 Td [(h)5(yphenat)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 326.744 Td [(h)5(yphenat)]TJ
 ET
 1 0 0 1 148.433 326.744 cm
 EMC
@@ -4653,7 +4653,7 @@ EMC
 /TD <</MCID 234>> BDC
 1 0 0 1 -77.978 -314.788 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 314.788 Td [(setspace)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 314.788 Td [(setspace)]TJ
 ET
 1 0 0 1 148.433 314.788 cm
 EMC
@@ -4674,7 +4674,7 @@ EMC
 /TD <</MCID 240>> BDC
 1 0 0 1 -77.978 -302.833 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 302.833 Td [(parskip)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 302.833 Td [(parskip)]TJ
 ET
 1 0 0 1 148.433 302.833 cm
 EMC
@@ -4695,14 +4695,14 @@ EMC
 /TD <</MCID 246>> BDC
 1 0 0 1 -77.978 -290.878 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 290.878 Td [(toclof)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 290.878 Td [(toclof)]TJ
 ET
 1 0 0 1 148.433 290.878 cm
 EMC
 /TD <</MCID 247>> BDC
 1 0 0 1 -148.433 -290.878 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 148.433 290.878 Td [(sub\002gure)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 148.433 290.878 Td [(sub\002gure)]TJ
 ET
 1 0 0 1 207.191 290.878 cm
 EMC
@@ -4720,14 +4720,14 @@ EMC
 /TD <</MCID 252>> BDC
 1 0 0 1 -77.978 -278.923 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 278.923 Td [(toclifbind)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 278.923 Td [(toclifbind)]TJ
 ET
 1 0 0 1 148.433 278.923 cm
 EMC
 /TD <</MCID 253>> BDC
 1 0 0 1 -148.433 -278.923 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 148.433 278.923 Td [(nottoc,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 0 -11.955 Td [(notlot,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 0 -11.955 Td [(notlof)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 148.433 278.923 Td [(nottoc,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 0 -11.955 Td [(notlot,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 0 -11.955 Td [(notlof)]TJ
 ET
 1 0 0 1 207.191 278.923 cm
 EMC
@@ -4745,7 +4745,7 @@ EMC
 /TD <</MCID 258>> BDC
 1 0 0 1 -77.978 -243.057 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 243.057 Td [(todonotes)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 243.057 Td [(todonotes)]TJ
 ET
 1 0 0 1 148.433 243.057 cm
 EMC
@@ -4755,21 +4755,21 @@ EMC
 /TD <</MCID 260>> BDC
 1 0 0 1 -207.191 -243.057 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 207.191 243.057 Td [(inline)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.185 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(mar)18(gin)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.535 0 Td [(to-do)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.522 0 Td [(notes)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 207.191 243.057 Td [(inline)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.185 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(mar)18(gin)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.535 0 Td [(to-do)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.522 0 Td [(notes)]TJ
 ET
 1 0 0 1 406.343 243.057 cm
 EMC
 /TD <</MCID 261>> BDC
 1 0 0 1 -406.343 -243.057 cm
 BT
-/F66 9.9626 Tf/F82 1 Tf( )Tj/F66 9.9626 Tf 406.343 243.057 Td [(X)]TJ
+/F67 9.9626 Tf/F84 1 Tf( )Tj/F67 9.9626 Tf 406.343 243.057 Td [(X)]TJ
 ET
 1 0 0 1 465.101 243.057 cm
 EMC
 /TD <</MCID 262>> BDC
 1 0 0 1 -465.101 -243.057 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 465.101 243.057 Td [(Notes)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.733 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(pref)10(aced)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf -40.388 -11.955 Td [(with)]TJ/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 20.204 0 Td [(T)92(o)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 13.201 0 Td [(Do:)]TJ/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 18.58 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf -62.226 -11.955 Td [(output)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 465.101 243.057 Td [(Notes)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.733 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(pref)10(aced)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf -40.388 -11.955 Td [(with)]TJ/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 20.204 0 Td [(T)92(o)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 13.201 0 Td [(Do:)]TJ/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 18.58 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf -62.226 -11.955 Td [(output)]TJ
 ET
 1 0 0 1 490.565 219.147 cm
 EMC
@@ -4779,7 +4779,7 @@ EMC
 /TD <</MCID 264>> BDC
 1 0 0 1 -77.978 -207.192 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 207.192 Td [(listings)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 207.192 Td [(listings)]TJ
 ET
 1 0 0 1 148.433 207.192 cm
 EMC
@@ -4800,7 +4800,7 @@ EMC
 /TD <</MCID 270>> BDC
 1 0 0 1 -77.978 -195.237 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 195.237 Td [(caption)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 195.237 Td [(caption)]TJ
 ET
 1 0 0 1 148.433 195.237 cm
 EMC
@@ -4821,7 +4821,7 @@ EMC
 /TD <</MCID 276>> BDC
 1 0 0 1 -77.978 -183.282 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 183.282 Td [(cmap)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 183.282 Td [(cmap)]TJ
 ET
 1 0 0 1 148.433 183.282 cm
 EMC
@@ -4842,7 +4842,7 @@ EMC
 /TD <</MCID 282>> BDC
 1 0 0 1 -77.978 -171.326 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 171.326 Td [(pdfcomment)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 171.326 Td [(pdfcomment)]TJ
 ET
 1 0 0 1 148.433 171.326 cm
 EMC
@@ -4852,14 +4852,14 @@ EMC
 /TD <</MCID 284>> BDC
 1 0 0 1 -207.191 -171.326 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 207.191 171.326 Td [(tool-tips.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.794 0 Td [(Also)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.31 0 Td [(calls)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.751 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(package)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 207.191 171.326 Td [(tool-tips.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.794 0 Td [(Also)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.31 0 Td [(calls)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.751 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(package)]TJ
 ET
 1 0 0 1 337.839 171.326 cm
 EMC
 /Span <</MCID 285>> BDC
 1 0 0 1 -337.839 -171.326 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 337.839 171.326 Td [(hyperref)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 337.839 171.326 Td [(hyperref)]TJ
 ET
 1 0 0 1 373.824 171.326 cm
 EMC
@@ -4869,14 +4869,14 @@ EMC
 /TD <</MCID 287>> BDC
 1 0 0 1 -406.343 -171.326 cm
 BT
-/F66 9.9626 Tf/F82 1 Tf( )Tj/F66 9.9626 Tf 406.343 171.326 Td [(X)]TJ
+/F67 9.9626 Tf/F84 1 Tf( )Tj/F67 9.9626 Tf 406.343 171.326 Td [(X)]TJ
 ET
 1 0 0 1 465.101 171.326 cm
 EMC
 /TD <</MCID 288>> BDC
 1 0 0 1 -465.101 -171.326 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 465.101 171.326 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(tool)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.992 0 Td [(tip)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 13.011 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(sup-)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf -54.804 -11.955 Td [(pressed)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 465.101 171.326 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(tool)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.992 0 Td [(tip)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 13.011 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(sup-)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf -54.804 -11.955 Td [(pressed)]TJ
 ET
 1 0 0 1 497.469 159.371 cm
 EMC
@@ -4886,7 +4886,7 @@ EMC
 /TD <</MCID 290>> BDC
 1 0 0 1 -77.978 -147.416 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.978 147.416 Td [(accessibility)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.978 147.416 Td [(accessibility)]TJ
 ET
 1 0 0 1 148.433 147.416 cm
 EMC
@@ -4896,7 +4896,7 @@ EMC
 /TD <</MCID 292>> BDC
 1 0 0 1 -207.191 -147.416 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 207.191 147.416 Td [(pro)15(vides)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.652 0 Td [(tags)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.54 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(structure)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 207.191 147.416 Td [(pro)15(vides)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.652 0 Td [(tags)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.54 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(structure)]TJ
 ET
 1 0 0 1 406.343 147.416 cm
 EMC
@@ -4920,7 +4920,7 @@ EMC
 /Artifact <</Type /Pagination>> BDC
 1 0 0 1 -72 -42.112 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 303.509 42.112 Td [(4)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 303.509 42.112 Td [(4)]TJ
 ET
 1 0 0 1 540 42.112 cm
 EMC
@@ -4928,142 +4928,142 @@ EMC
 
 endstream
 endobj
-405 0 obj
+407 0 obj
 <<
 /Type /Page
-/Contents 406 0 R
-/Resources 404 0 R
+/Contents 408 0 R
+/Resources 406 0 R
 /MediaBox [0 0 612 792]
-/Parent 152 0 R
-/Annots [ 306 0 R ]
+/Parent 154 0 R
+/Annots [ 308 0 R ]
 >>
 endobj
-306 0 obj
+308 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /F 4/Border[0 0 0]/H/I/C[1 0 0]
 /Rect [238.573 417.802 260.49 430.136]
-/A << /S /GoTo /D (subsubsection.0.3.1) >>
+/A << /S /GoTo /D (subsubsection.0.3.2.1) >>
 >>
 endobj
-407 0 obj
+409 0 obj
 <<
-/D [405 0 R /XYZ 71 718.907 null]
+/D [407 0 R /XYZ 71 718.907 null]
 >>
 endobj
-154 0 obj
+156 0 obj
 <<
-/D [405 0 R /XYZ 72 620.661 null]
+/D [407 0 R /XYZ 72 620.661 null]
 >>
 endobj
-404 0 obj
+406 0 obj
 <<
  /ColorSpace 3 0 R /Pattern 2 0 R /ExtGState 1 0 R 
-/Font << /F81 144 0 R /F82 145 0 R /F92 243 0 R /F107 402 0 R /F79 141 0 R /F101 398 0 R /F66 408 0 R /F85 146 0 R /F86 147 0 R /F91 235 0 R >>
+/Font << /F83 146 0 R /F84 147 0 R /F94 245 0 R /F108 404 0 R /F80 143 0 R /F102 400 0 R /F67 410 0 R /F87 148 0 R /F88 149 0 R /F93 237 0 R >>
 /ProcSet [ /PDF /Text ]
 >>
 endobj
-393 0 obj
-<</Type /StructElem /P 391 0 R /K [ <</Type /MCR /Pg 245  0 R /MCID 339>> 394 0 R <</Type /MCR /Pg 245  0 R /MCID 341>> <</Type /MCR /Pg 409 0 R /MCID 342>>] /S /P /Lang(EN)>>
-endobj
-411 0 obj
-<</Type /StructElem /P 410 0 R /K <</Type /MCR /Pg 409  0 R /MCID 344>> /S /Span  /Lang(EN)  >>
-endobj
-412 0 obj
-<</Type /StructElem /P 410 0 R /K <</Type /MCR /Pg 409  0 R /MCID 346>> /S /Span  /Lang(EN)  >>
-endobj
-410 0 obj
-<</Type /StructElem /P 391 0 R /K [ <</Type /MCR /Pg 409  0 R /MCID 343>> 411 0 R <</Type /MCR /Pg 409  0 R /MCID 345>> 412 0 R <</Type /MCR /Pg 409  0 R /MCID 347>>] /S /P /Lang(EN)>>
+395 0 obj
+<</Type /StructElem /P 393 0 R /K [ <</Type /MCR /Pg 247  0 R /MCID 339>> 396 0 R <</Type /MCR /Pg 247  0 R /MCID 341>> <</Type /MCR /Pg 411 0 R /MCID 342>>] /S /P /Lang(EN)>>
 endobj
 413 0 obj
-<</Type /StructElem /P 391 0 R /K [ <</Type /MCR /Pg 409  0 R /MCID 348>> <</Type /MCR /Pg 409  0 R /MCID 349>> <</Type /MCR /Pg 409  0 R /MCID 350>> <</Type /MCR /Pg 409  0 R /MCID 351>>] /S /Code /Lang(EN)  >>
-endobj
-391 0 obj
-<</Type /StructElem /P 352 0 R /T (Problems with embedded fonts) /Lang(EN)/K [ 392 0 R 393 0 R 410 0 R 413 0 R] /S /Subsubsection>>
-endobj
-352 0 obj
-<</Type /StructElem /P 191 0 R /T (Accessibility support) /Lang(EN)/K [ 353 0 R 354 0 R 356 0 R 391 0 R] /S /Subsection>>
-endobj
-415 0 obj
-<</Type /StructElem /P 414 0 R /K [ <</Type /MCR /Pg 409  0 R /MCID 352>>] /S /H /Lang(EN)  >>
-endobj
-417 0 obj
-<</Type /StructElem /P 416 0 R /K [<</Type /MCR /Pg 409  0 R /MCID 354>> <</Type /OBJR /Obj 418 0 R>>] /S /Reference>>
-endobj
-416 0 obj
-<</Type /StructElem /P 414 0 R /K [ <</Type /MCR /Pg 409  0 R /MCID 353>>417 0 R   <</Type /MCR /Pg 409  0 R /MCID 355>>] /S /P /Lang(EN)>>
+<</Type /StructElem /P 412 0 R /K <</Type /MCR /Pg 411  0 R /MCID 344>> /S /Span  /Lang(EN)  >>
 endobj
 414 0 obj
-<</Type /StructElem /P 191 0 R /T (A template) /Lang(EN)/K [ 415 0 R 416 0 R] /S /Subsection>>
+<</Type /StructElem /P 412 0 R /K <</Type /MCR /Pg 411  0 R /MCID 346>> /S /Span  /Lang(EN)  >>
 endobj
-420 0 obj
-<</Type /StructElem /P 419 0 R /K [ <</Type /MCR /Pg 409  0 R /MCID 356>>] /S /H /Lang(EN)  >>
+412 0 obj
+<</Type /StructElem /P 393 0 R /K [ <</Type /MCR /Pg 411  0 R /MCID 343>> 413 0 R <</Type /MCR /Pg 411  0 R /MCID 345>> 414 0 R <</Type /MCR /Pg 411  0 R /MCID 347>>] /S /P /Lang(EN)>>
+endobj
+415 0 obj
+<</Type /StructElem /P 393 0 R /K [ <</Type /MCR /Pg 411  0 R /MCID 348>> <</Type /MCR /Pg 411  0 R /MCID 349>> <</Type /MCR /Pg 411  0 R /MCID 350>> <</Type /MCR /Pg 411  0 R /MCID 351>>] /S /Code /Lang(EN)  >>
+endobj
+393 0 obj
+<</Type /StructElem /P 354 0 R /T (Problems with embedded fonts) /Lang(EN)/K [ 394 0 R 395 0 R 412 0 R 415 0 R] /S /Subsubsection>>
+endobj
+354 0 obj
+<</Type /StructElem /P 193 0 R /T (Accessibility support) /Lang(EN)/K [ 355 0 R 356 0 R 358 0 R 393 0 R] /S /Subsection>>
+endobj
+417 0 obj
+<</Type /StructElem /P 416 0 R /K [ <</Type /MCR /Pg 411  0 R /MCID 352>>] /S /H /Lang(EN)  >>
+endobj
+419 0 obj
+<</Type /StructElem /P 418 0 R /K [<</Type /MCR /Pg 411  0 R /MCID 354>> <</Type /OBJR /Obj 420 0 R>>] /S /Reference>>
+endobj
+418 0 obj
+<</Type /StructElem /P 416 0 R /K [ <</Type /MCR /Pg 411  0 R /MCID 353>>419 0 R   <</Type /MCR /Pg 411  0 R /MCID 355>>] /S /P /Lang(EN)>>
+endobj
+416 0 obj
+<</Type /StructElem /P 193 0 R /T (A template) /Lang(EN)/K [ 417 0 R 418 0 R] /S /Subsection>>
 endobj
 422 0 obj
-<</Type /StructElem /P 421 0 R /K <</Type /MCR /Pg 409  0 R /MCID 358>> /S /Span  /Lang(EN)  >>
-endobj
-423 0 obj
-<</Type /StructElem /P 421 0 R /K <</Type /MCR /Pg 409  0 R /MCID 360>> /S /Span  /Lang(EN)  >>
+<</Type /StructElem /P 421 0 R /K [ <</Type /MCR /Pg 411  0 R /MCID 356>>] /S /H /Lang(EN)  >>
 endobj
 424 0 obj
-<</Type /StructElem /P 421 0 R /K [<</Type /MCR /Pg 409  0 R /MCID 362>> <</Type /OBJR /Obj 425 0 R>>] /S /Reference>>
+<</Type /StructElem /P 423 0 R /K <</Type /MCR /Pg 411  0 R /MCID 358>> /S /Span  /Lang(EN)  >>
 endobj
-421 0 obj
-<</Type /StructElem /P 419 0 R /K [ <</Type /MCR /Pg 409  0 R /MCID 357>> 422 0 R <</Type /MCR /Pg 409  0 R /MCID 359>> 423 0 R <</Type /MCR /Pg 409  0 R /MCID 361>>424 0 R   <</Type /MCR /Pg 409  0 R /MCID 363>> <</Type /MCR /Pg 409 0 R /MCID 364>>] /S /P /Lang(EN)>>
-endobj
-427 0 obj
-<</Type /StructElem /P 426 0 R /K <</Type /MCR /Pg 409  0 R /MCID 366>> /S /Span  /Lang(EN)  >>
-endobj
-428 0 obj
-<</Type /StructElem /P 426 0 R /K <</Type /MCR /Pg 409  0 R /MCID 368>> /S /Span  /Lang(EN)  >>
-endobj
-429 0 obj
-<</Type /StructElem /P 426 0 R /K <</Type /MCR /Pg 409  0 R /MCID 370>> /S /Span  /Lang(EN)  >>
-endobj
-430 0 obj
-<</Type /StructElem /P 426 0 R /K <</Type /MCR /Pg 409  0 R /MCID 372>> /S /Span  /Lang(EN)  >>
-endobj
-431 0 obj
-<</Type /StructElem /P 426 0 R /K <</Type /MCR /Pg 409  0 R /MCID 374>> /S /Span  /Lang(EN)  >>
-endobj
-432 0 obj
-<</Type /StructElem /P 426 0 R /K <</Type /MCR /Pg 409  0 R /MCID 376>> /S /Span  /Lang(EN)  >>
-endobj
-433 0 obj
-<</Type /StructElem /P 426 0 R /K <</Type /MCR /Pg 409  0 R /MCID 378>> /S /Span  /Lang(EN)  >>
-endobj
-434 0 obj
-<</Type /StructElem /P 426 0 R /K <</Type /MCR /Pg 409  0 R /MCID 380>> /S /Span  /Lang(EN)  >>
+425 0 obj
+<</Type /StructElem /P 423 0 R /K <</Type /MCR /Pg 411  0 R /MCID 360>> /S /Span  /Lang(EN)  >>
 endobj
 426 0 obj
-<</Type /StructElem /P 419 0 R /K [ <</Type /MCR /Pg 409  0 R /MCID 365>> 427 0 R <</Type /MCR /Pg 409  0 R /MCID 367>> 428 0 R <</Type /MCR /Pg 409  0 R /MCID 369>> 429 0 R <</Type /MCR /Pg 409  0 R /MCID 371>> 430 0 R <</Type /MCR /Pg 409  0 R /MCID 373>> 431 0 R <</Type /MCR /Pg 409  0 R /MCID 375>> 432 0 R <</Type /MCR /Pg 409  0 R /MCID 377>> 433 0 R <</Type /MCR /Pg 409  0 R /MCID 379>> 434 0 R <</Type /MCR /Pg 409  0 R /MCID 381>>] /S /P /Lang(EN)>>
+<</Type /StructElem /P 423 0 R /K [<</Type /MCR /Pg 411  0 R /MCID 362>> <</Type /OBJR /Obj 427 0 R>>] /S /Reference>>
+endobj
+423 0 obj
+<</Type /StructElem /P 421 0 R /K [ <</Type /MCR /Pg 411  0 R /MCID 357>> 424 0 R <</Type /MCR /Pg 411  0 R /MCID 359>> 425 0 R <</Type /MCR /Pg 411  0 R /MCID 361>>426 0 R   <</Type /MCR /Pg 411  0 R /MCID 363>> <</Type /MCR /Pg 411 0 R /MCID 364>>] /S /P /Lang(EN)>>
+endobj
+429 0 obj
+<</Type /StructElem /P 428 0 R /K <</Type /MCR /Pg 411  0 R /MCID 366>> /S /Span  /Lang(EN)  >>
+endobj
+430 0 obj
+<</Type /StructElem /P 428 0 R /K <</Type /MCR /Pg 411  0 R /MCID 368>> /S /Span  /Lang(EN)  >>
+endobj
+431 0 obj
+<</Type /StructElem /P 428 0 R /K <</Type /MCR /Pg 411  0 R /MCID 370>> /S /Span  /Lang(EN)  >>
+endobj
+432 0 obj
+<</Type /StructElem /P 428 0 R /K <</Type /MCR /Pg 411  0 R /MCID 372>> /S /Span  /Lang(EN)  >>
+endobj
+433 0 obj
+<</Type /StructElem /P 428 0 R /K <</Type /MCR /Pg 411  0 R /MCID 374>> /S /Span  /Lang(EN)  >>
+endobj
+434 0 obj
+<</Type /StructElem /P 428 0 R /K <</Type /MCR /Pg 411  0 R /MCID 376>> /S /Span  /Lang(EN)  >>
 endobj
 435 0 obj
-<</Type /StructElem /P 419 0 R /K [ <</Type /MCR /Pg 409  0 R /MCID 382>>] /S /P /Lang(EN)>>
+<</Type /StructElem /P 428 0 R /K <</Type /MCR /Pg 411  0 R /MCID 378>> /S /Span  /Lang(EN)  >>
 endobj
 436 0 obj
-<</Type /StructElem /P 419 0 R /K [ <</Type /MCR /Pg 409  0 R /MCID 383>> <</Type /MCR /Pg 409  0 R /MCID 384>> <</Type /MCR /Pg 409  0 R /MCID 385>>] /S /Code /Lang(EN)  >>
+<</Type /StructElem /P 428 0 R /K <</Type /MCR /Pg 411  0 R /MCID 380>> /S /Span  /Lang(EN)  >>
 endobj
-438 0 obj
-<</Type /StructElem /P 437 0 R /K <</Type /MCR /Pg 409  0 R /MCID 387>> /S /Span  /Lang(EN)  >>
+428 0 obj
+<</Type /StructElem /P 421 0 R /K [ <</Type /MCR /Pg 411  0 R /MCID 365>> 429 0 R <</Type /MCR /Pg 411  0 R /MCID 367>> 430 0 R <</Type /MCR /Pg 411  0 R /MCID 369>> 431 0 R <</Type /MCR /Pg 411  0 R /MCID 371>> 432 0 R <</Type /MCR /Pg 411  0 R /MCID 373>> 433 0 R <</Type /MCR /Pg 411  0 R /MCID 375>> 434 0 R <</Type /MCR /Pg 411  0 R /MCID 377>> 435 0 R <</Type /MCR /Pg 411  0 R /MCID 379>> 436 0 R <</Type /MCR /Pg 411  0 R /MCID 381>>] /S /P /Lang(EN)>>
 endobj
 437 0 obj
-<</Type /StructElem /P 419 0 R /K [ <</Type /MCR /Pg 409  0 R /MCID 386>> 438 0 R <</Type /MCR /Pg 409  0 R /MCID 388>>] /S /P /Lang(EN)>>
+<</Type /StructElem /P 421 0 R /K [ <</Type /MCR /Pg 411  0 R /MCID 382>>] /S /P /Lang(EN)>>
+endobj
+438 0 obj
+<</Type /StructElem /P 421 0 R /K [ <</Type /MCR /Pg 411  0 R /MCID 383>> <</Type /MCR /Pg 411  0 R /MCID 384>> <</Type /MCR /Pg 411  0 R /MCID 385>>] /S /Code /Lang(EN)  >>
 endobj
 440 0 obj
-<</Type /StructElem /P 439 0 R /K <</Type /MCR /Pg 409  0 R /MCID 390>> /S /Span  /Lang(EN)  >>
+<</Type /StructElem /P 439 0 R /K <</Type /MCR /Pg 411  0 R /MCID 387>> /S /Span  /Lang(EN)  >>
 endobj
 439 0 obj
-<</Type /StructElem /P 419 0 R /K [ <</Type /MCR /Pg 409  0 R /MCID 389>> 440 0 R <</Type /MCR /Pg 409  0 R /MCID 391>>] /S /P /Lang(EN)>>
+<</Type /StructElem /P 421 0 R /K [ <</Type /MCR /Pg 411  0 R /MCID 386>> 440 0 R <</Type /MCR /Pg 411  0 R /MCID 388>>] /S /P /Lang(EN)>>
 endobj
-443 0 obj
-<</Type /StructElem /P 442 0 R /K [ <</Type /MCR /Pg 409  0 R /MCID 392>>] /S /Lbl /Lang(EN)  >>
+442 0 obj
+<</Type /StructElem /P 441 0 R /K <</Type /MCR /Pg 411  0 R /MCID 390>> /S /Span  /Lang(EN)  >>
+endobj
+441 0 obj
+<</Type /StructElem /P 421 0 R /K [ <</Type /MCR /Pg 411  0 R /MCID 389>> 442 0 R <</Type /MCR /Pg 411  0 R /MCID 391>>] /S /P /Lang(EN)>>
 endobj
 445 0 obj
-<</Type /StructElem /P 444 0 R /K <</Type /MCR /Pg 409  0 R /MCID 394>> /S /Span  /Lang(EN)  >>
+<</Type /StructElem /P 444 0 R /K [ <</Type /MCR /Pg 411  0 R /MCID 392>>] /S /Lbl /Lang(EN)  >>
 endobj
 447 0 obj
+<</Type /StructElem /P 446 0 R /K <</Type /MCR /Pg 411  0 R /MCID 394>> /S /Span  /Lang(EN)  >>
+endobj
+449 0 obj
 <<
 /Length 29567     
 >>
@@ -5095,7 +5095,7 @@ EMC
 /P <</MCID 323>> BDC
 1 0 0 1 -176.918 -490.351 cm
 BT
-/F81 8.9664 Tf/F82 1 Tf( )Tj/F81 8.9664 Tf 176.918 490.351 Td [(\050a\051)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf 13.449 0 Td [(A)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf 8.966 0 Td [(c)10(hic)20(k.)]TJ
+/F83 8.9664 Tf/F84 1 Tf( )Tj/F83 8.9664 Tf 176.918 490.351 Td [(\050a\051)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf 13.449 0 Td [(A)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf 8.966 0 Td [(c)10(hic)20(k.)]TJ
 0 g 0 G
 ET
 1 0 0 1 384.756 504 cm
@@ -5119,7 +5119,7 @@ EMC
 /P <</MCID 330>> BDC
 1 0 0 1 -421.372 -490.351 cm
 BT
-/F81 8.9664 Tf/F82 1 Tf( )Tj/F81 8.9664 Tf 421.372 490.351 Td [(\050b\051)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf 13.942 0 Td [(Another)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf 36.861 0 Td [(c)10(hic)20(k)]TJ
+/F83 8.9664 Tf/F84 1 Tf( )Tj/F83 8.9664 Tf 421.372 490.351 Td [(\050b\051)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf 13.942 0 Td [(Another)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf 36.861 0 Td [(c)10(hic)20(k)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -5128,7 +5128,7 @@ EMC
 /Caption <</MCID 331>> BDC
 1 0 0 1 -72 -487.064 cm
 BT
-/F81 8.9664 Tf/F82 1 Tf( )Tj/F81 8.9664 Tf 260.129 469.43 Td [(Figure)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf 29.893 0 Td [(1.)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf 10.562 0 Td [(T)60(est)]TJ/F82 1 Tf( )Tj/F81 8.9664 Tf 20.39 0 Td [(ima)10(g)-10(es)]TJ
+/F83 8.9664 Tf/F84 1 Tf( )Tj/F83 8.9664 Tf 260.129 469.43 Td [(Figure)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf 29.893 0 Td [(1.)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf 10.562 0 Td [(T)60(est)]TJ/F84 1 Tf( )Tj/F83 8.9664 Tf 20.39 0 Td [(ima)10(g)-10(es)]TJ
 ET
 1 0 0 1 72 466.142 cm
 EMC
@@ -5138,27 +5138,27 @@ EMC
 /P <</MCID 342>> BDC
 1 0 0 1 -72 -446.217 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 436.254 Td [(look)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(at)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.664 0 Td [(`fonts')]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.051 0 Td [(tag)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.664 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(properties.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.419 0 Td [(If)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.126 0 Td [(an)15(y)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 436.254 Td [(look)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(at)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.664 0 Td [(`fonts')]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.051 0 Td [(tag)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.664 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(properties.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.419 0 Td [(If)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.126 0 Td [(an)15(y)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -210.05 -11.955 Td [(fonts)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.416 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(not)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.222 0 Td [(sho)25(wn)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.254 0 Td [(as)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(being)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.627 0 Td [(an)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -210.05 -11.955 Td [(fonts)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.416 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(not)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.222 0 Td [(sho)25(wn)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.254 0 Td [(as)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(being)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.627 0 Td [(an)]TJ
 ET
 1 0 0 1 199.859 424.299 cm
 EMC
 /Span <</MCID 340>> BDC
 1 0 0 1 -199.859 -424.299 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 199.859 424.299 Td [(embedded)]TJ/F82 1 Tf( )Tj/F85 9.9626 Tf 42.879 0 Td [(subset)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 199.859 424.299 Td [(embedded)]TJ/F84 1 Tf( )Tj/F87 9.9626 Tf 42.879 0 Td [(subset)]TJ
 ET
 1 0 0 1 267.824 424.299 cm
 EMC
 /P <</MCID 341>> BDC
 1 0 0 1 -267.824 -424.299 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 267.824 424.299 Td [(,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 4.981 0 Td [(you)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 267.824 424.299 Td [(,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 4.981 0 Td [(you)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -200.805 -11.955 Td [(need)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(try)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 13.559 0 Td [(ag)5(ain.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -200.805 -11.955 Td [(need)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(try)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 13.559 0 Td [(ag)5(ain.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -5167,53 +5167,53 @@ EMC
 /P <</MCID 343>> BDC
 1 0 0 1 -72 -394.401 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 394.401 Td [(Encapsulated)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 55.611 0 Td [(postscript)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.235 0 Td [(\002gures)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.608 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(particularly)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 48.418 0 Td [(prone)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 394.401 Td [(Encapsulated)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 55.611 0 Td [(postscript)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.235 0 Td [(\002gures)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.608 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(particularly)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 48.418 0 Td [(prone)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -189.527 -11.955 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(ha)20(ving)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.41 0 Td [(unde\002ned)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(fonts.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.504 0 Td [(Check)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.945 0 Td [(by)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.454 0 Td [(compiling)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 42.898 0 Td [(your)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -189.527 -11.955 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(ha)20(ving)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.41 0 Td [(unde\002ned)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(fonts.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.504 0 Td [(Check)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.945 0 Td [(by)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.454 0 Td [(compiling)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 42.898 0 Td [(your)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -190.235 -11.955 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(draft)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(mode,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.118 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(seeing)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.945 0 Td [(if)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 8.578 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.664 0 Td [(fonts)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.416 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(still)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -190.235 -11.955 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(draft)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(mode,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.118 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(seeing)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.945 0 Td [(if)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 8.578 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.664 0 Td [(fonts)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.416 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(still)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -205.577 -11.955 Td [(present)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.262 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(output)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.955 0 Td [(PDF)80(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.455 0 Td [(T)80(o)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.762 0 Td [(\002x)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 13.012 0 Td [(this)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.886 0 Td [(problem,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.186 0 Td [(you)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(could)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -205.577 -11.955 Td [(present)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.262 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(output)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.955 0 Td [(PDF)80(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.455 0 Td [(T)80(o)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.762 0 Td [(\002x)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 13.012 0 Td [(this)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.886 0 Td [(problem,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.186 0 Td [(you)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(could)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -204.86 -11.955 Td [(consider)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.244 0 Td [(changing)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.013 0 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -204.86 -11.955 Td [(consider)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.244 0 Td [(changing)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.013 0 Td [(the)]TJ
 ET
 1 0 0 1 161.922 346.581 cm
 EMC
 /Span <</MCID 344>> BDC
 1 0 0 1 -161.922 -346.581 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 161.922 346.581 Td [(.eps)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 161.922 346.581 Td [(.eps)]TJ
 ET
 1 0 0 1 177.693 346.581 cm
 EMC
 /P <</MCID 345>> BDC
 1 0 0 1 -177.693 -346.581 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 180.183 346.581 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(a)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 180.183 346.581 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(a)]TJ
 ET
 1 0 0 1 212.562 346.581 cm
 EMC
 /Span <</MCID 346>> BDC
 1 0 0 1 -212.562 -346.581 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 212.562 346.581 Td [(.png)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 212.562 346.581 Td [(.png)]TJ
 ET
 1 0 0 1 229.996 346.581 cm
 EMC
 /P <</MCID 347>> BDC
 1 0 0 1 -229.996 -346.581 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 229.996 346.581 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 5.579 0 Td [(If)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.126 0 Td [(you)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(wish)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.309 0 Td [(to)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 229.996 346.581 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 5.579 0 Td [(If)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.126 0 Td [(you)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(wish)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.309 0 Td [(to)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -211.445 -11.956 Td [(do)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(this)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.887 0 Td [(`on)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.77 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(\003y',)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.82 0 Td [(you)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(could)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.628 0 Td [(use)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.77 0 Td [(this)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.887 0 Td [(approach)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.003 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(your)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -211.445 -11.956 Td [(do)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(this)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.887 0 Td [(`on)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.77 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(\003y',)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.82 0 Td [(you)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(could)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.628 0 Td [(use)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.77 0 Td [(this)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.887 0 Td [(approach)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.003 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(your)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -202.559 -11.955 Td [(preamble:)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -202.559 -11.955 Td [(preamble:)]TJ
 0 g 0 G
 0 g 0 G
 1 g 1 G
@@ -5229,7 +5229,7 @@ Q
 0 g 0 G
 0.5 g 0.5 G
 BT
-/F79 4.9813 Tf/F82 1 Tf( )Tj/F79 4.9813 Tf 64.528 294.765 Td [(2)]TJ
+/F80 4.9813 Tf/F84 1 Tf( )Tj/F80 4.9813 Tf 64.528 294.765 Td [(2)]TJ
 0 g 0 G
 ET
 1 0 0 1 72 294.765 cm
@@ -5238,11 +5238,11 @@ EMC
 /P <</MCID 348>> BDC
 1 0 0 1 -72 -283.806 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 73.444 283.806 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 73.444 283.806 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 4.432 0 Td [(u)-55(s)-56(e)-55(p)-55(a)-55(c)-56(k)-55(a)-55(g)-55(e)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 4.432 0 Td [(u)-55(s)-56(e)-55(p)-55(a)-55(c)-56(k)-55(a)-55(g)-55(e)]TJ
 0 g 0 G
- [-189({)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 59.643 0 Td [(e)-107(p)-107(s)-107(t)-107(o)-108(p)-107(d)-107(f)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 43.271 0 Td [(})]TJ
+ [-189({)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 59.643 0 Td [(e)-107(p)-107(s)-107(t)-107(o)-108(p)-107(d)-107(f)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 43.271 0 Td [(})]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -5251,7 +5251,7 @@ EMC
 /P <</MCID 349>> BDC
 1 0 0 1 -72 -272.847 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 73.444 272.847 Td [(\134)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.852 0 Td [(e)-102(p)-102(s)-103(t)-102(o)-102(p)-102(d)-103(f)-102(D)-102(e)-102(c)-102(l)-103(a)-102(r)-102(e)-102(G)-103(r)-102(a)-102(p)-102(h)-102(i)-103(c)-102(s)-102(R)-102(u)-103(l)-102(e)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 73.444 272.847 Td [(\134)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.852 0 Td [(e)-102(p)-102(s)-103(t)-102(o)-102(p)-102(d)-103(f)-102(D)-102(e)-102(c)-102(l)-103(a)-102(r)-102(e)-102(G)-103(r)-102(a)-102(p)-102(h)-102(i)-103(c)-102(s)-102(R)-102(u)-103(l)-102(e)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -5260,7 +5260,7 @@ EMC
 /P <</MCID 350>> BDC
 1 0 0 1 -72 -261.889 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 79.137 261.889 Td [({)-196(.)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 9.424 0 Td [(e)-47(p)-47(s)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 17.308 0 Td [(})-177({)-211(p)-33(n)-33(g)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 27.224 0 Td [(})]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.909 0 Td [({)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.909 0 Td [(.)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.703 0 Td [(p)-33(n)-33(g)-210(})-178({)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 27.636 0 Td [(c)-115(o)-115(n)-115(v)-116(e)-115(r)-115(t)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 79.137 261.889 Td [({)-196(.)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 9.424 0 Td [(e)-47(p)-47(s)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 17.308 0 Td [(})-177({)-211(p)-33(n)-33(g)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 27.224 0 Td [(})]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.909 0 Td [({)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.909 0 Td [(.)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.703 0 Td [(p)-33(n)-33(g)-210(})-178({)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 27.636 0 Td [(c)-115(o)-115(n)-115(v)-116(e)-115(r)-115(t)]TJ
 0 g 0 G
 0 g 0 G
 1 g 1 G
@@ -5275,7 +5275,7 @@ Q
 1 g 1 G
 0 g 0 G
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 72.421 250.93 Td [(e)-47(p)-47(s)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 17.644 0 Td [(:)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.417 0 Td [(\134)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 5.413 0 Td [(S)-111(o)-111(u)-111(r)-111(c)-111(e)-111(F)-111(i)-111(l)-111(e)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 54.728 0 Td [(.)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.418 0 Td [(\134)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 5.123 0 Td [(S)-79(o)-78(u)-79(r)-79(c)-78(e)-79(E)-79(x)-79(t)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 72.421 250.93 Td [(e)-47(p)-47(s)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 17.644 0 Td [(:)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.417 0 Td [(\134)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 5.413 0 Td [(S)-111(o)-111(u)-111(r)-111(c)-111(e)-111(F)-111(i)-111(l)-111(e)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 54.728 0 Td [(.)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.418 0 Td [(\134)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 5.123 0 Td [(S)-79(o)-78(u)-79(r)-79(c)-78(e)-79(E)-79(x)-79(t)]TJ
 0 g 0 G
 0 g 0 G
 1 g 1 G
@@ -5290,7 +5290,7 @@ Q
 1 g 1 G
 0 g 0 G
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 72.296 239.971 Td [(p)-33(n)-33(g)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 17.769 0 Td [(:)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.417 0 Td [(\134)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 5.548 0 Td [(O)-126(u)-126(t)-126(p)-126(u)-126(t)-127(F)-126(i)-126(l)-126(e)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 53.861 0 Td [(})]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 72.296 239.971 Td [(p)-33(n)-33(g)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 17.769 0 Td [(:)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.417 0 Td [(\134)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 5.548 0 Td [(O)-126(u)-126(t)-126(p)-126(u)-126(t)-127(F)-126(i)-126(l)-126(e)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 53.861 0 Td [(})]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -5299,7 +5299,7 @@ EMC
 /P <</MCID 351>> BDC
 1 0 0 1 -72 -229.012 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 73.444 229.012 Td [(\134)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.675 0 Td [(A)-82(p)-83(p)-82(e)-83(n)-82(d)-83(G)-82(r)-83(a)-82(p)-82(h)-83(i)-82(c)-83(s)-82(E)-83(x)-82(t)-83(e)-82(n)-82(s)-83(i)-82(o)-83(n)-82(s)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 130.135 0 Td [({)-196(.)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 9.299 0 Td [(p)-33(n)-33(g)-166(})]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 73.444 229.012 Td [(\134)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.675 0 Td [(A)-82(p)-83(p)-82(e)-83(n)-82(d)-83(G)-82(r)-83(a)-82(p)-82(h)-83(i)-82(c)-83(s)-82(E)-83(x)-82(t)-83(e)-82(n)-82(s)-83(i)-82(o)-83(n)-82(s)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 130.135 0 Td [({)-196(.)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 9.299 0 Td [(p)-33(n)-33(g)-166(})]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -5312,7 +5312,7 @@ EMC
 /H <</MCID 352>> BDC
 1 0 0 1 -72 -190.49 cm
 BT
-/F92 9.9626 Tf/F82 1 Tf( )Tj/F92 9.9626 Tf 72 190.49 Td [(3.3)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 23.81 0 Td [(A)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 9.963 0 Td [(template)]TJ
+/F94 9.9626 Tf/F84 1 Tf( )Tj/F94 9.9626 Tf 72 190.49 Td [(3.3)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 23.81 0 Td [(A)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 9.963 0 Td [(template)]TJ
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 g 0 G
@@ -5323,10 +5323,10 @@ EMC
 /P <</MCID 353>> BDC
 1 0 0 1 -72 -171.423 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 171.423 Td [(The)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.982 0 Td [(code)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(used)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.753 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(produce)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.58 0 Td [(this)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 171.423 Td [(The)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.982 0 Td [(code)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(used)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.753 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(produce)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.58 0 Td [(this)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -104.856 -11.956 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(a)20(v)25(ailable)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.006 0 Td [(from)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -104.856 -11.956 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(a)20(v)25(ailable)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.006 0 Td [(from)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -5336,7 +5336,7 @@ EMC
 0 g 0 G
 1 0 0 1 -72 -147.512 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 147.512 Td [(https://github)40(.com/AndyClifton/AccessibleMetaClass)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 147.512 Td [(https://github)40(.com/AndyClifton/AccessibleMetaClass)]TJ
 0 g 0 G
 ET
 1 0 0 1 285.526 147.512 cm
@@ -5344,7 +5344,7 @@ EMC
 /P <</MCID 355>> BDC
 1 0 0 1 -285.526 -147.512 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 285.526 147.512 Td [(.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 285.526 147.512 Td [(.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -5355,10 +5355,10 @@ EMC
 /H <</MCID 356>> BDC
 1 0 0 1 -72 -114.978 cm
 BT
-/F92 9.9626 Tf/F82 1 Tf( )Tj/F92 9.9626 Tf 72 114.978 Td [(3.4)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 23.81 0 Td [(Changing)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 48.707 0 Td [(to)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 12.175 0 Td [(a)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 8.308 0 Td [(WYSIWYG-readab)10(le)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 96.228 0 Td [(f)20(ormat)]TJ
+/F94 9.9626 Tf/F84 1 Tf( )Tj/F94 9.9626 Tf 72 114.978 Td [(3.4)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 23.81 0 Td [(Changing)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 48.707 0 Td [(to)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 12.175 0 Td [(a)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 8.308 0 Td [(WYSIWYG-readab)10(le)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 96.228 0 Td [(f)20(ormat)]TJ
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
-/F82 1 Tf( )Tj/F92 9.9626 Tf -165.418 -11.955 Td [(using)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 29.34 0 Td [(Late)15(x2r)-20(tf)]TJ
+/F84 1 Tf( )Tj/F94 9.9626 Tf -165.418 -11.955 Td [(using)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 29.34 0 Td [(Late)15(x2r)-20(tf)]TJ
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 g 0 G
@@ -5371,31 +5371,31 @@ EMC
 /Span <</MCID 358>> BDC
 1 0 0 1 -72 -83.955 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 72 83.955 Td [(latex2rtf)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 72 83.955 Td [(latex2rtf)]TJ
 ET
 1 0 0 1 107.994 83.955 cm
 EMC
 /P <</MCID 359>> BDC
 1 0 0 1 -107.994 -83.955 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 110.485 83.955 Td [(reads)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 110.485 83.955 Td [(reads)]TJ
 ET
 1 0 0 1 133.997 83.955 cm
 EMC
 /Span <</MCID 360>> BDC
 1 0 0 1 -133.997 -83.955 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 133.997 83.955 Td [(.te)20(x)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 133.997 83.955 Td [(.te)20(x)]TJ
 ET
 1 0 0 1 147.934 83.955 cm
 EMC
 /P <</MCID 361>> BDC
 1 0 0 1 -147.934 -83.955 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 150.425 83.955 Td [(\002les)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.098 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(con)40(v)15(erts)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.696 0 Td [(common)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 150.425 83.955 Td [(\002les)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.098 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(con)40(v)15(erts)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.696 0 Td [(common)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -150.095 -11.955 Td [(L)]TJ/F79 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(Xcommands)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 52.852 0 Td [(into)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.992 0 Td [(their)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(rich)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.982 0 Td [(te)15(xt)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.285 0 Td [(format)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.051 0 Td [(equi)25(v)25(alent.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -150.095 -11.955 Td [(L)]TJ/F80 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(Xcommands)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 52.852 0 Td [(into)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.992 0 Td [(their)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(rich)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.982 0 Td [(te)15(xt)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.285 0 Td [(format)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.051 0 Td [(equi)25(v)25(alent.)]TJ
 0 g 0 G
 ET
 1 0 0 1 72 72 cm
@@ -5407,7 +5407,7 @@ EMC
 /P <</MCID 364>> BDC
 1 0 0 1 -310.981 -446.217 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 436.254 Td [(It)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 8.578 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(do)25(wnloaded)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 50.939 0 Td [(from)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 436.254 Td [(It)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 8.578 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(do)25(wnloaded)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 50.939 0 Td [(from)]TJ
 ET
 1 0 0 1 420.57 436.254 cm
 EMC
@@ -5415,10 +5415,10 @@ EMC
 0 g 0 G
 1 0 0 1 -420.57 -436.254 cm
 BT
-/F101 9.9626 Tf/F82 1 Tf( )Tj/F101 9.9626 Tf 420.57 436.254 Td [(http://latex2rtf.)]TJ
+/F102 9.9626 Tf/F84 1 Tf( )Tj/F102 9.9626 Tf 420.57 436.254 Td [(http://latex2rtf.)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F101 9.9626 Tf -109.589 -11.955 Td [(sourceforge.net)]TJ
+/F84 1 Tf( )Tj/F102 9.9626 Tf -109.589 -11.955 Td [(sourceforge.net)]TJ
 0 g 0 G
 ET
 1 0 0 1 400.645 424.299 cm
@@ -5426,7 +5426,7 @@ EMC
 /P <</MCID 363>> BDC
 1 0 0 1 -400.645 -424.299 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 400.645 424.299 Td [(.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 400.645 424.299 Td [(.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -5435,149 +5435,149 @@ EMC
 /P <</MCID 365>> BDC
 1 0 0 1 -310.981 -405.709 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 405.709 Td [(W)80(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.522 0 Td [(w)10(ant)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.758 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(use)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.77 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(same)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.964 0 Td [(source)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.493 0 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.222 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(PDF)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.762 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(for)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 405.709 Td [(W)80(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.522 0 Td [(w)10(ant)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.758 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(use)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.77 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(same)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.964 0 Td [(source)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.493 0 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.222 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(PDF)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.762 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(for)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -211.047 -11.956 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(con)40(v)15(ersion)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.659 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(WYSIWYG-readable)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 88.796 0 Td [(format.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.14 0 Td [(T)80(o)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -211.047 -11.956 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(con)40(v)15(ersion)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.659 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(WYSIWYG-readable)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 88.796 0 Td [(format.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.14 0 Td [(T)80(o)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -198.415 -11.955 Td [(ensure)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.493 0 Td [(compatibility)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 55.631 0 Td [(between)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.686 0 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -198.415 -11.955 Td [(ensure)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.493 0 Td [(compatibility)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 55.631 0 Td [(between)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.686 0 Td [(the)]TJ
 ET
 1 0 0 1 445.455 381.798 cm
 EMC
 /Span <</MCID 366>> BDC
 1 0 0 1 -445.455 -381.798 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 445.455 381.798 Td [(.te)20(x)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 445.455 381.798 Td [(.te)20(x)]TJ
 ET
 1 0 0 1 459.393 381.798 cm
 EMC
 /P <</MCID 367>> BDC
 1 0 0 1 -459.393 -381.798 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 461.884 381.798 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.222 0 Td [(and)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 461.884 381.798 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.222 0 Td [(and)]TJ
 ET
 1 0 0 1 493.983 381.798 cm
 EMC
 /Span <</MCID 368>> BDC
 1 0 0 1 -493.983 -381.798 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 493.983 381.798 Td [(latex2rtf)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 493.983 381.798 Td [(latex2rtf)]TJ
 ET
 1 0 0 1 529.977 381.798 cm
 EMC
 /P <</MCID 369>> BDC
 1 0 0 1 -529.977 -381.798 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 529.977 381.798 Td [(,)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 529.977 381.798 Td [(,)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -218.996 -11.955 Td [(we)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(limit)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.32 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(packages)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.003 0 Td [(used)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -218.996 -11.955 Td [(we)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(limit)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.32 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(packages)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.003 0 Td [(used)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(the)]TJ
 ET
 1 0 0 1 445.734 369.843 cm
 EMC
 /Span <</MCID 370>> BDC
 1 0 0 1 -445.734 -369.843 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 445.734 369.843 Td [(meta)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 445.734 369.843 Td [(meta)]TJ
 ET
 1 0 0 1 465.659 369.843 cm
 EMC
 /P <</MCID 371>> BDC
 1 0 0 1 -465.659 -369.843 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 468.15 369.843 Td [(class)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(those)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 468.15 369.843 Td [(class)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(those)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -189.268 -11.955 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.318 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.896 0 Td [(understood)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 46.764 0 Td [(by)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -189.268 -11.955 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.318 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.896 0 Td [(understood)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 46.764 0 Td [(by)]TJ
 ET
 1 0 0 1 415.847 357.888 cm
 EMC
 /Span <</MCID 372>> BDC
 1 0 0 1 -415.847 -357.888 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 415.847 357.888 Td [(latex2rtf)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 415.847 357.888 Td [(latex2rtf)]TJ
 ET
 1 0 0 1 451.842 357.888 cm
 EMC
 /P <</MCID 373>> BDC
 1 0 0 1 -451.842 -357.888 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 451.842 357.888 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 5.579 0 Td [(Also,)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 451.842 357.888 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 5.579 0 Td [(Also,)]TJ
 ET
 1 0 0 1 481.221 357.888 cm
 EMC
 /Span <</MCID 374>> BDC
 1 0 0 1 -481.221 -357.888 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 481.221 357.888 Td [(latex2rtf)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 481.221 357.888 Td [(latex2rtf)]TJ
 ET
 1 0 0 1 517.216 357.888 cm
 EMC
 /P <</MCID 375>> BDC
 1 0 0 1 -517.216 -357.888 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 519.706 357.888 Td [(can)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 519.706 357.888 Td [(can)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -208.725 -11.955 Td [(read)]TJ/F107 9.9626 Tf/F82 1 Tf( )Tj/F107 9.9626 Tf 19.637 0 Td [(input)]TJ/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 32.378 0 Td [(\002les)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.098 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(has)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.77 0 Td [(some)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.522 0 Td [(capacity)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.686 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(deal)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.088 0 Td [(with)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -208.725 -11.955 Td [(read)]TJ/F108 9.9626 Tf/F84 1 Tf( )Tj/F108 9.9626 Tf 19.637 0 Td [(input)]TJ/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 32.378 0 Td [(\002les)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.098 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(has)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.77 0 Td [(some)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.522 0 Td [(capacity)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.686 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(deal)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.088 0 Td [(with)]TJ
 0 g 0 G
 0 g 0 G
-/F107 9.9626 Tf/F82 1 Tf( )Tj/F107 9.9626 Tf -192.297 -11.955 Td [(\134newcommand)]TJ/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 65.754 0 Td [(s.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.454 0 Td [(Therefore,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.254 0 Td [(we)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(ha)20(v)15(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.951 0 Td [(created)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.253 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.222 0 Td [(to)]TJ
+/F108 9.9626 Tf/F84 1 Tf( )Tj/F108 9.9626 Tf -192.297 -11.955 Td [(\134newcommand)]TJ/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 65.754 0 Td [(s.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.454 0 Td [(Therefore,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.254 0 Td [(we)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(ha)20(v)15(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.951 0 Td [(created)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.253 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.222 0 Td [(to)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -207.909 -11.956 Td [(remap)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.387 0 Td [(all)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(en)40(vironments)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 56.328 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(a)20(v)25(ailable)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.007 0 Td [(using)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -207.909 -11.956 Td [(remap)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.387 0 Td [(all)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(en)40(vironments)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 56.328 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(a)20(v)25(ailable)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.007 0 Td [(using)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -191.719 -11.955 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -191.719 -11.955 Td [(the)]TJ
 ET
 1 0 0 1 325.646 310.067 cm
 EMC
 /Span <</MCID 376>> BDC
 1 0 0 1 -325.646 -310.067 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 325.646 310.067 Td [(meta)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 325.646 310.067 Td [(meta)]TJ
 ET
 1 0 0 1 345.571 310.067 cm
 EMC
 /P <</MCID 377>> BDC
 1 0 0 1 -345.571 -310.067 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 348.062 310.067 Td [(class)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.857 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(simpler)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.378 0 Td [(forms)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.733 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.318 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.896 0 Td [(understood)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 348.062 310.067 Td [(class)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.857 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(simpler)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.378 0 Td [(forms)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.733 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.318 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.896 0 Td [(understood)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -172.94 -11.955 Td [(by)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -172.94 -11.955 Td [(by)]TJ
 ET
 1 0 0 1 323.435 298.112 cm
 EMC
 /Span <</MCID 378>> BDC
 1 0 0 1 -323.435 -298.112 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 323.435 298.112 Td [(latex2rtf)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 323.435 298.112 Td [(latex2rtf)]TJ
 ET
 1 0 0 1 359.429 298.112 cm
 EMC
 /P <</MCID 379>> BDC
 1 0 0 1 -359.429 -298.112 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 359.429 298.112 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 5.579 0 Td [(This)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.135 0 Td [(called)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 359.429 298.112 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 5.579 0 Td [(This)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.135 0 Td [(called)]TJ
 ET
 1 0 0 1 435.851 298.112 cm
 EMC
 /Span <</MCID 380>> BDC
 1 0 0 1 -435.851 -298.112 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 435.851 298.112 Td [(Late)20(x2rtf_meta_with_-)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 435.851 298.112 Td [(Late)20(x2rtf_meta_with_-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F85 9.9626 Tf -124.87 -11.955 Td [(acc.te)20(x)]TJ
+/F84 1 Tf( )Tj/F87 9.9626 Tf -124.87 -11.955 Td [(acc.te)20(x)]TJ
 ET
 1 0 0 1 338.747 286.157 cm
 EMC
 /P <</MCID 381>> BDC
 1 0 0 1 -338.747 -286.157 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 338.747 286.157 Td [(.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 338.747 286.157 Td [(.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -5586,10 +5586,10 @@ EMC
 /P <</MCID 382>> BDC
 1 0 0 1 -310.981 -267.567 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 267.567 Td [(If)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.126 0 Td [(you)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.079 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(command)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(line)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(v)15(ersion)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.671 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(Late)15(x2rtf,)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 267.567 Td [(If)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.126 0 Td [(you)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.079 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(command)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(line)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(v)15(ersion)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.671 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(Late)15(x2rtf,)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -181.638 -11.956 Td [(you)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(con)40(v)15(ert)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.82 0 Td [(your)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(late)15(x)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.709 0 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.222 0 Td [(using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.08 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(commands,)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -181.638 -11.956 Td [(you)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(con)40(v)15(ert)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.82 0 Td [(your)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(late)15(x)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.709 0 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.222 0 Td [(using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.08 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(commands,)]TJ
 0 g 0 G
 0 g 0 G
 1 g 1 G
@@ -5605,7 +5605,7 @@ Q
 0 g 0 G
 0.5 g 0.5 G
 BT
-/F79 4.9813 Tf/F82 1 Tf( )Tj/F79 4.9813 Tf 303.509 227.059 Td [(2)]TJ
+/F80 4.9813 Tf/F84 1 Tf( )Tj/F80 4.9813 Tf 303.509 227.059 Td [(2)]TJ
 0 g 0 G
 ET
 1 0 0 1 310.981 227.059 cm
@@ -5614,7 +5614,7 @@ EMC
 /P <</MCID 383>> BDC
 1 0 0 1 -310.981 -216.1 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 312.308 216.1 Td [(l)-148(a)-148(t)-148(e)-148(x)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 31.872 0 Td [(f)-102(o)-103(o)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 16.664 0 Td [(.)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.981 0 Td [(t)-116(e)-117(x)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 312.308 216.1 Td [(l)-148(a)-148(t)-148(e)-148(x)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 31.872 0 Td [(f)-102(o)-103(o)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 16.664 0 Td [(.)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.981 0 Td [(t)-116(e)-117(x)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -5623,7 +5623,7 @@ EMC
 /P <</MCID 384>> BDC
 1 0 0 1 -310.981 -205.141 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 312.308 205.141 Td [(l)-148(a)-148(t)-148(e)-148(x)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 31.872 0 Td [(f)-102(o)-103(o)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 16.664 0 Td [(.)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.981 0 Td [(t)-116(e)-117(x)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 312.308 205.141 Td [(l)-148(a)-148(t)-148(e)-148(x)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 31.872 0 Td [(f)-102(o)-103(o)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 16.664 0 Td [(.)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.981 0 Td [(t)-116(e)-117(x)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -5632,7 +5632,7 @@ EMC
 /P <</MCID 385>> BDC
 1 0 0 1 -310.981 -194.182 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 312.308 194.182 Td [(l)-148(a)-148(t)-148(e)-148(x)-170(2)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 32.995 0 Td [(r)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 5.028 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.535 0 Td [(f)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 10.833 0 Td [(f)-103(o)-102(o)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 312.308 194.182 Td [(l)-148(a)-148(t)-148(e)-148(x)-170(2)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 32.995 0 Td [(r)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 5.028 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.535 0 Td [(f)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 10.833 0 Td [(f)-103(o)-102(o)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -5644,33 +5644,33 @@ EMC
 /P <</MCID 386>> BDC
 1 0 0 1 -310.981 -168.956 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 168.956 Td [(Y)110(ou)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.551 0 Td [(may)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.646 0 Td [(get)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(some)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.521 0 Td [(error)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.848 0 Td [(messages,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 42.61 0 Td [(which)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.839 0 Td [(may)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.646 0 Td [(or)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(may)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 168.956 Td [(Y)110(ou)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.551 0 Td [(may)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.646 0 Td [(get)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(some)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.521 0 Td [(error)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.848 0 Td [(messages,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 42.61 0 Td [(which)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.839 0 Td [(may)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.646 0 Td [(or)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(may)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -198.116 -11.955 Td [(not)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(important.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.324 0 Td [(Check)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.945 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.222 0 Td [(w)10(as)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.883 0 Td [(produced)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.561 0 Td [(by)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.454 0 Td [(open-)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -198.116 -11.955 Td [(not)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(important.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.324 0 Td [(Check)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.945 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.222 0 Td [(w)10(as)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.883 0 Td [(produced)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.561 0 Td [(by)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.454 0 Td [(open-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -199.172 -11.955 Td [(ing)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -199.172 -11.955 Td [(ing)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(the)]TJ
 ET
 1 0 0 1 340.869 145.046 cm
 EMC
 /Span <</MCID 387>> BDC
 1 0 0 1 -340.869 -145.046 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 340.869 145.046 Td [(.rtf)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 340.869 145.046 Td [(.rtf)]TJ
 ET
 1 0 0 1 354.229 145.046 cm
 EMC
 /P <</MCID 388>> BDC
 1 0 0 1 -354.229 -145.046 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 356.719 145.046 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(your)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(f)10(a)20(v)20(orite)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.976 0 Td [(WYSIWYG)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 51.736 0 Td [(package.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.217 0 Td [(If)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 356.719 145.046 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(your)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(f)10(a)20(v)20(orite)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.976 0 Td [(WYSIWYG)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 51.736 0 Td [(package.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.217 0 Td [(If)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -214.883 -11.955 Td [(it)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 8.03 0 Td [(w)10(orks,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.23 0 Td [(sa)20(v)15(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.846 0 Td [(it)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 8.029 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(proprietary)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 46.754 0 Td [(format,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.542 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(distrib)20(ute)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -214.883 -11.955 Td [(it)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 8.03 0 Td [(w)10(orks,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.23 0 Td [(sa)20(v)15(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.846 0 Td [(it)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 8.029 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(proprietary)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 46.754 0 Td [(format,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.542 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(distrib)20(ute)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -187.983 -11.955 Td [(it)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 8.03 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(your)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(non-L)]TJ/F79 7.3723 Tf 20.762 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(Xing)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.416 0 Td [(co)25(w)10(ork)10(ers.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -187.983 -11.955 Td [(it)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 8.03 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(your)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(non-L)]TJ/F80 7.3723 Tf 20.762 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(Xing)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.416 0 Td [(co)25(w)10(ork)10(ers.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -5679,24 +5679,24 @@ EMC
 /P <</MCID 389>> BDC
 1 0 0 1 -310.981 -102.545 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 102.545 Td [(The)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.983 0 Td [(follo)25(wing)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.986 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(suggested)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.782 0 Td [(as)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(best)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.54 0 Td [(practices)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 37.897 0 Td [(when)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 102.545 Td [(The)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.983 0 Td [(follo)25(wing)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.986 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(suggested)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.782 0 Td [(as)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(best)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.54 0 Td [(practices)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 37.897 0 Td [(when)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -182.633 -11.955 Td [(w)10(orking)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.597 0 Td [(with)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -182.633 -11.955 Td [(w)10(orking)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.597 0 Td [(with)]TJ
 ET
 1 0 0 1 366.782 90.59 cm
 EMC
 /Span <</MCID 390>> BDC
 1 0 0 1 -366.782 -90.59 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 366.782 90.59 Td [(latex2rtf)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 366.782 90.59 Td [(latex2rtf)]TJ
 ET
 1 0 0 1 402.776 90.59 cm
 EMC
 /P <</MCID 391>> BDC
 1 0 0 1 -402.776 -90.59 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 402.776 90.59 Td [(:)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 402.776 90.59 Td [(:)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -5707,7 +5707,7 @@ EMC
 /Lbl <</MCID 392>> BDC
 1 0 0 1 -306 -72 cm
 BT
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 313.472 72 Td [(Con)40(v)10(ert)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 36.852 0 Td [(early)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 24.069 0 Td [(and)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 18.55 0 Td [(often.)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 313.472 72 Td [(Con)40(v)10(ert)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 36.852 0 Td [(early)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 24.069 0 Td [(and)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 18.55 0 Td [(often.)]TJ
 ET
 1 0 0 1 420.101 72 cm
 EMC
@@ -5716,7 +5716,7 @@ EMC
 /LBody <</MCID 393>> BDC
 1 0 0 1 -425.083 -72 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 425.083 72 Td [(Check)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.945 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(your)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(document)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 425.083 72 Td [(Check)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.945 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(your)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(document)]TJ
 0 g 0 G
 ET
 1 0 0 1 310.981 72 cm
@@ -5727,7 +5727,7 @@ EMC
 /Artifact <</Type /Pagination>> BDC
 1 0 0 1 -72 -42.112 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 303.509 42.112 Td [(5)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 303.509 42.112 Td [(5)]TJ
 ET
 1 0 0 1 540 42.112 cm
 EMC
@@ -5735,17 +5735,17 @@ EMC
 
 endstream
 endobj
-409 0 obj
+411 0 obj
 <<
 /Type /Page
-/Contents 447 0 R
-/Resources 446 0 R
+/Contents 449 0 R
+/Resources 448 0 R
 /MediaBox [0 0 612 792]
-/Parent 152 0 R
-/Annots [ 373 0 R 381 0 R 418 0 R 425 0 R 452 0 R 453 0 R ]
+/Parent 154 0 R
+/Annots [ 375 0 R 383 0 R 420 0 R 427 0 R 454 0 R 455 0 R ]
 >>
 endobj
-370 0 obj
+372 0 obj
 <<
 /Type /XObject
 /Subtype /Image
@@ -5937,21 +5937,21 @@ WHLC#6+e*¬w˚’˚À	˚¿˝ø˛≥˛®˝î˝b˝]˝W˝M
 ¯B˚(¸%¸"˚%ˆ4Óx>˜≠h˝√{˝«~¸…˝ ˛ÀÄ˝ÕÇ˚…}˛”Ö˚œÅ¸ŒÅ˙Õ˘ŒÅ˘÷ï¸‡•˝Ïø˝Ô≈ˇÀ˛Ô…˝Ó…˛ÓÃˇÔŒ˛Ó…˛Õ˛Û‹˛Û›˛Û›˝Ùﬂ˛˜‚¸ı‡˝ı‚˝˜Â˛¯Ê˛ı·ˇ˘Â˛˚Íˇ˚È˛¯Ê˝¯Ê˝˘Ê˛ıÂ˝ı‰˛˝Ôˇ˛Ú˝¸Îˇ˛Òˇ˛ˆˇ˝ˆˇ˝Ùˇˇıˇˇ˘˝˝ı˝˛˜ˇˇ¸ˇˇ˚ˇˇ˙ˇˇ˙ˇˇ˚ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ¸ˇˇ¸˛Û‰˛Û‰˛Û„˛ÚÂˇÒ‚ˇÚ·ˇÚ‚˛Ú‚˛‡ˇ·˛‡ˇÒ·ˇﬁˇ⁄˛Ô⁄˛Ô◊˛Ô÷˛Ô’˝Ó’˛Ó÷˛Ó’˛Ì“ˇÌœ˛ÌÕ˝Ó…¸Ï«˝Ï»¸Í∆¸Îƒ˝ËΩ˝Ë∫˚‰µ˝Âµ¸·Æ˝‚Æ˚‡¨˝ﬂ¨˝ﬁ´˚‹•¸€¢˚Ÿ†˜÷õ¯‘ó¯‘ñ˜‘ï˜“ê¯—è˘Œç¯ÃãÛ∆ÑÙ«ÑÙ«ÑÙƒÄÓΩwÔ¿tºrÒµlÏ¨aË°OÁöDÁï?‚ç;Êê:Êö>ÂúA‚úAÊùC„ô=‡ñ:ﬂí5‡è1‡é3ŸÉ+ŸÄ+ÿj’[‘N‡A„9ÍGÎZÏá3Ìö<Áú?‰ò:Ëú<Ï†@Îù>‰ì5Îó;ÏúEÈöCËô?Ëó:Áï7Áî9ÔõAÛüCÙ•LÚ£Oˆ©Uı©Wı£QÒüFÚú6Úì/Óá.ˆÇ/ÛaˆZ˘W˘U˘a˜ÅC˜Øm˚œå˚“ë¸÷ì˚ÿï˝‹ô˚‚ü˝‡üˇ‰´˛Â¨˝Ê±¸Ë∂˝Ïø˙‚≤¯ﬂ¨Û‚Ø˘Èº˛Ô»˛Ô ˛ÃˇÒœ˛—˛Ô–˛Ò”ˇÙ›˛Û›˛Ùﬁˇ˜·ˇ˜„˝Ù‡¸Ù‡˝˜„˝ˆ‰˝Ù‡˝˜„¸˘Ë˝˙È˝¯Êˇ˚Í˛˚È˛¯Á˙Ù„ˇ˝ˇ˛Úˇ˝Ôˇ˛Ûˇ˝ˆˇ˛˜ˇ˛ıˇˇˆˇˇ˘ˇˇ˘˛ˇ˜ˇˇ˚ˇˇ˚ˇˇ˙ˇˇ˜ˇˇ˘ˇˇ˚ˇˇ˚ˇˇ˚ˇˇ˚ˇˇ˚ˇˇ¸ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ¸ˇˇ˝ˇˇ˝˛ˇ˙ˇˇ˚ˇˇ˚¸Û‰¸Û‰˝ÙÂ˛ÙÂ˛Ò·ˇÛ‚˛Ú‚˛Ò·˝Ò·ˇÛ„˛Ò·˛Ò·˛‡ˇÔﬂˇÔﬂˇ›ˇ⁄˝Ô÷˝ÓÿˇÔ⁄˛Ôÿ˛Ô’ˇÓ”˛Ì–¸ÏÀ˝ÓÀ˝ÌÃ˝Î…˝Ï∆¸Î¿¸Î¿¸Áª˛Ë∏¸Â¥˛Áµ˚‰≥˝‚¥˝·≤˝·≠¸ﬂ®˚‹§˘⁄¢˘Ÿõ¯ÿô˘Ÿö˘◊ñ˙◊ó˘’î˜“íıŒåˆœãˆÕâ˜ áÛ∆ÑÙ»ÄÚƒ|ÚøxªtÔ∫lÌ∏hÓµfÎ´^Ø_Î≠WÍ≠VÍ≠WÌ≠YÍßV‰¢PÂ£OÁ£LÍ£MﬂóB‚ñC·á8ﬂ~1‹o$ÂaÎ\Úc&q.ÍñGÏ¢OÈ§OÎ©PØTØT¨R´PÙÆTı≤_ÒÆ[Ô≠UÓ≠RÔÆRÔ≠SÙ≤[˜∂`˜∑b˜∑`˙∫d˘πf˙∂d¯¥_˘µZ¯ØTˆ•M˚®R˘óD¯ã;˘Ñ8˚â<˙ã=ÚüV˘ø{˚“í˚’ï¸⁄ò¸‹ö˛ﬂü˚Âß˝‰¶ˇÈ≤˛È≥˝Í∂˚Îπ˝Ó¡˙Ë∑˙ÂØ˙Ë≤¸Ì¬˛ÒŒ˝–˛ÚŒ˛Ò—˛Ú‘¸Ò‘˝Ò‘˛Û€˛Ú‹ˇÙﬁˇˆ·ˇı‚˛Û‡˝Ûﬁ˛˜·˛ˆ„˝ı‡ˇ˘‰˝˙Í˝˙Í˝˙È˛˚Í˝˚Í˛˚Í¸˘Ëˇ˛Òˇ˛Úˇ˛Úˇ˝Ùˇ˛ˆˇ˛˜ˇˇˆˇˇ¯ˇˇ˚ˇˇ¸ˇˇ¯ˇˇ˚ˇˇ¸ˇˇ˙ˇ˛Ûˇ˛ıˇˇ˙ˇˇ˙ˇˇ˙ˇˇ˙ˇˇ˙ˇˇ¸ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˚ˇˇ˝ˇˇ˛˛˛˙ˇˇ¸ˇˇ˝˝ÙÂ˝ıÊ¸Ù‰˛ÙÂ˝Ò·¸‡˝Ò·˛Ú‚˛Ò·˛Ú‚˛Ò·˛Ú‚˛·ˇÔ‡ˇ·ˇ›˛Ô⁄˝Ô’˛ÔŸˇ€˛⁄ˇÔ◊˛Ì’˛Ó‘˝ÌŒ˝ÌŒ˝ÌŒ˛ÏÀ¸Í»˝Ï√¸Ï√˝Ëæ˛Áª˝Ëª˛Íº¸Ë∫˝„∏¸‚∂˝„±¸·≠˚ﬂ™¸ﬂ´˚›§˚›£¸›£˚€ü¸€ü˙Ÿù¯÷ô¯’ï¯‘í¯”ê˘—ê¯–è˜œäˆÃáı≈Éı≈ÅÛ√zÚƒxÔ¡vÌºqÚærÒ∫jÓ∑fÔ∑gÔµfÌ≤dË≠_Î∞aÌ∞^ÔØ^ÁßWÍ®YÈüRËúNÂîFÍÜ?ÌÄ;Íz7ÎÖ?Î£VÏ™[ÏÆ]Ô¥`Ò∂bÙ∫eıπdı∑c˜∫f¯ºmÚ∏hıªfˆºfˆºg˜Ωg˘¡m˘¬p˜¡o¯¬n˚∆s˚≈v˘ƒw˘≈u˚«r˘ƒq˘¡s˛»z˝√q˝øl¸πh˝æoˆ∂f¯»|˙‘è˝€ù˝ﬁ°˝‡°¸‡¢˝‰ß¸È∞˝Á≠ˇÎπ˝Íπ˛ÌΩ¸Ì¿¸Ó≈˝Ì¬˛ÏΩ˝Ïø˝ÔÀ˛Û”˝Ú‘˛Ú—ˇÒ‘ˇÚ◊˝Ò◊˝Ûÿ˛Ú€˝Û›˛Û›ˇı·ˇÛ‡˛Û‡˝Ûﬁ˛ˆ‡˛ˆ‚˝Ù‡˛¯„˚¯Ë¸˘È˛˚Í˛¸Î˝˚Í˛˚Í˝˙Èˇ˛Òˇ˛Úˇ˛Úˇ˝Ùˇ˛˜ˇ˛˜ˇˇ˜ˇˇ˘ˇˇ˚ˇˇ¸˛ˇ˜ˇˇ˚ˇˇ¸ˇˇ˙ˇ˛Ûˇ˛ıˇˇ˙ˇˇ˙ˇˇ˙ˇˇ˙ˇˇ˙ˇˇ¸ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˚ˇˇ˝ˇˇ˛˛˛˙ˇˇ¸ˇˇ˝˛ıÊ˛Ù‰¸Û„ˇÙÊ˝Ú‚¸ﬂ˛Ò‚˝‡˝Ú‚˝Ò·˛Ú‚˝Ò·˛Ò‡ˇ‡ˇ·ˇÒﬁ˛€˛ÿ˛€˝Ô€˛ÔŸˇÔ⁄ˇÓ⁄ˇÔ⁄ˇÔ÷ˇÔ÷˛Ì‘ˇÌ“ˇÌ–ˇÓÕ˛ÓÃ˝Íƒ˙Âæ˚Í≈˚Í≈¸Ï∆¸Êæ˝Áæ˚Áπ¸Êπ˘·¥˝‰∫¸‚≥˝·≤˘›¨˝‡Æ¸ﬂ¨¸›™˘€•¸ﬁ¢˚›ü˘€ùˆÿô˘⁄ù˘÷ô˙‘ò˘œï˙—ïˆ–éˆ—çıŒã˜Œä¯Ãá˘Àá˜…Ñ˜ Öˆ ÇÔ√{Ô¬zÚ«~Úƒ|Ú¡zÛ¿z¯ƒ~Ú¿zÒ¡yÚ¬yˆøx˜√yÙºsıæuı¡wˆ≈zı»}¯ÀÄˆ ˙ŒÑ˜ Å˚ŒÖ˘ÀÇ¯ÀÉ˜ Å˙ŒÄ˘ÃÄ˘ÕÇ˙œÖ˚“à˘—Ü˚”à¸Ÿé˚ÿè˘÷ê¸◊î˝’î¸÷ê˝÷ì˙÷î˝›õ˝›õ˚ﬂõ˘›ô˛„•˛‚¢˝ﬂ†¸‚¶˚ÁØ˚Ë≤¸Ë±¸Ë±¸Íµ¸Ïº˝Í∫ˇÌ≈˝Ï≈˝ ¸Ã˝Ú—˝—˛”˛‘˛Û⁄¸ˆ⁄˝ÙŸ˛Ú◊ˇÚŸˇÛ€˛Û‹˛Ù›˛Ù‡ˇˆ‡¸Ò⁄˛Ùﬂ˝Ò‹˝Ò›¸Ò€˝˜·˝˜„˝ˆ„¸ı‚˝˚Î˝˚Ï˛˝Ï˚¯Á˝˙Í˛¸Ï˛¸Ïˇ˛Úˇ˛ÛˇˇÙˇ˛ıˇˇ˜ˇ˛˜ˇˇ˜ˇ˛˜ˇˇ˘˛˛˙˝˛ˆˇˇ˙ˇˇ˚ˇ˛˘ˇ˛Ùˇ˛ıˇˇ˙ˇˇ˙ˇˇ˚ˇˇ˚ˇˇ˚ˇˇ¸ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ¸ˇˇ˛ˇˇ˛ˇˇ¸ˇˇ˝ˇˇ˝ˇ˜Ë˛Ò‡˝Û‰˛ˆÁ˝Û‚¸Ô›ˇÒ„˛Ò·˙Ó‹˘Ì‹˛Ú‚˛Ú·ˇÒﬂ˛ﬁˇÒ·ˇÚﬂˇ›ˇÒ›ˇÒ‡˛ﬁ¸Ìÿ˛ÔŸ˛ÓŸ˛Ô⁄ˇ⁄ˇÔŸ¸Ì◊˛Ô’˛Ô’ˇ’˛Ô”˝Ì«˚Ë¬¸Ï»¸Ì ˝Î∆˘‰ª˚Ëæ˚Îø˚Ëº˘„¥˛ÁΩ˝Ê∫˝‡¥¯⁄´˝„¥¸·≤¸ﬁ¨˚ﬁ™˚ﬁ©˚ﬁ©˚ﬁ¶¯⁄°˙‹£˙Ÿ†˙◊ü˘’ù˚÷õ˙÷ó˜”ï˜—ë˘“è˘—é˙“ê˘—è¯–é¯–ãÙÕáÛÃá˜œâˆÃáıÀÜ¯…Ü˘ à¯ Ü¯ÀÜ¯ÀÖ˘ Ñ˚Õá˜»Å¯ É˜ŒÖ¯–á˙‘ä˚’ã˘“ä¸‘ê˘“ç¸’é˙”ç˚”ç˚”ç¸‘ç¸‘å˚’ç˚Ÿì¸ÿï˚⁄ñ¸Ÿï˝›ò¸ﬁô¸ﬁô¸›ô¸‹ô¸€õ˛›ù˛›ü˛·•¸‡¶˚‚®˙‚¶˛Ë∞˛ÁÆ¸‡•˚‚®¸È∑¸È∂˝Íπ˝Î∏˛Ïπ˛Ï¬˛Ï¡ˇÌÀ˛Î…˛Ã˝œ˛Ú”¸’¸÷˛÷ˇÛ⁄˝ıﬁ˝ı›˛ı€˛ˆ‹˛ı›˛Ùﬂ˛ı‡˝Ù‡ˇˆ‚˝Û⁄˛ı›˚⁄˝Ò‹¸Ò€˛¯‰˝¯Â˝ˆ‰˝ˆ‰˛¸Ó˛¸ˇ˛Ò˝˙È˛¸Ïˇ˝Ô˛˝Ôˇ˝Ûˇ˛ıˇ˛ˆˇ˝ıˇ˝ˆˇ˛ˆˇ˛ıˇ˝ÛˇˇÙˇ˝˜ˇ˝ˆˇˇ¯ˇ˛¯ˇ˝˜ˇˇ˜ˇˇ˜˛ˇ˘ˇˇ˚ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˝ˇˇ˛ˇˇˇˇˇˇˇˇ˛ˇˇ˝ˇˇ˝˝ÙÂ˝Ô›˝Ù‰˙ÛÂ˚Ôﬁ¸Ó€ˇÒ‰ˇÚ„˝Òﬁ˝Ò‡˛Ú‚˛Ò·˝‹ˇ›ˇÔﬂ˛›˝Ô‹˛ﬁˇ‡ˇÒ‡˛ÔŸ˛ÔŸ˛€˛€ˇ€ˇ€˛⁄˛ÿ˛÷˛÷˝◊˘È«˚È ˛Ó–˝Ô”˝Í ˝Á«˛ÍÀ˚Î…˙È¿˛Î≈˛Î∆¸Í¬˝‰Ω˝‰π˝ÈΩ˛ËΩ˚·±˝„≥¸‰¥˚„≥˙·Ø˚·¨˝„Æ˚ﬁ™˙‹®˚›©˚‹•¸›§¯Ÿ†˘ÿû˙◊ù˚ÿû˘◊ô˚Ÿö˙ÿô˙Ÿö¯÷ò˙ÿö˙◊ö¸◊ö˙’ò˙◊ñ˘◊ñ˙◊ñ˙÷ñ˘÷ñ˚ÿò˚ÿò˘÷ï˙◊ó˚Ÿô˘ÿò¸€ö¸€ö˚⁄ö˚ÿû˘◊ú˚Ÿú¸€ù˙‹û˚ﬂ†˝ﬁü˝›ú¸‹õ˛‚¶ˇ„©˝Ê™˚‚®˝ÂÆ¸Ê∞˛Ë∞˙„¶˚„¶˝‰≠˛Ê±˛ÁµˇÎº˝Èπ˛Î∫˛Ë∏˛Ìø˝Îº¸Â≥˝Í∏˛Ó«˝Óƒ˛Ó»˛Ó∆˛Ó∆˝Ó ¸Ó…ˇÒ‘˛Ó—˛Ú”¸Ú’˝ÛŸ˛Û›˛Û›˝Ò⁄˛Ùﬂ˝¯Ê¸˜‰˝ˆ·˛˜„˛˜‰˝¯Ê˛˘Á˛˘Íˇ˚Í¸˜‚˝¯„˛¯„˝˜‚¸Ùﬂˇ˘Ê˝˙Ë˛˜Ê˝ˆÂˇ¸Ó˛¸ˇ˝Ú˝˙Íˇ¸Ï˝¸Ôˇ˝Ò˛˝ÒˇˇÚ˛˝Òˇ˝Òˇ˝ˇ˛Úˇ˝Úˇ˝Òˇ˝Òˇ˝ıˇ˝ˆˇ˛˜ˇ˛˜ˇ˝ˆˇ˛˜˝˝ı˛ˇ˜ˇˇ˚˛˛¸˛˛¸ˇˇ˝ˇˇ˝ˇˇ˝˛˛¸ˇˇ˚ˇˇ˘˛ˇ¯ˇˇ˛ˇˇˇˇˇˇ˛ˇ˚˛ˇ¯˝˛˜˚Ò„¸ﬁ˝ıÂ˚ÙÂ˙Î€˙Î⁄ˇÒ‰ˇÚ„˛Òﬁ˛Ú‚ˇÚ„˝Ò·¸Ó€˛ﬁˇﬂ˝Ô‹¸Ó⁄ˇÒ·ˇÒ‚ˇÒ‡˛⁄˛⁄˝Ô⁄˚Ì◊ˇ€˛€˛‹˙Ï‘˝÷˛Ô◊˛Ôÿ˚ÍÀ¸ÎÕ¸Ï–˛Ô’˝ÍÕ¸Ê≈˚Ë≈˚Î∆˘Ëæ¸Î…¸Î«˝Ì∆˝Á¿˝Êº˚Ëæ˝Ëø˚„∂˛Êπ˝Á∫˝Áπ˙„≥¸‰±˝Â≤˙‡Æ˘ﬁ¨˚·Æ¸ﬂ´˝·™˙›ß˘⁄§˚⁄•˚€¶˘Ÿû˚€†˚‹†˚€°¯ÿû˙⁄°˙Ÿ†¸Ÿ†˙◊û˙€ù˘€õ˚‹ú˙⁄û˙⁄ü˝ﬁ¢¸‹°˘Ÿù˙⁄û¸›†˘Ÿù¸›°¸ﬁ°¸›°¸‹•˙⁄¢˚‹¢¸ﬁ§¯›¢˚·•¸·¶˝ﬂ£¸›°˝‰¨˛‰Ø¸È≤˚ÂØ˝È∑˚È∏˝Íπ˙ÂÆ¸Â≠˚Â±˝Áµ˝ÍΩ˛Ì≈˛Ï¬˛Ï¡˛Íø˛Ó≈¸Ï¬˝Èª˛Ï¿˛ÔÃ˛À˛ÔÕ˛Õ˛Õ˝œ¸ÕˇÚ÷˝Ô‘˛Û◊¸ÙŸ˝Ù‹˛ÛﬂˇÛﬂ¸Ú›˝ˆ‚¸¯Ë˝˜Â˛ı‰ˇ¯Âˇ¯Ê¸˘Ë˝˘È˛˙Ìˇ¸Ì˙˜‰˝˘Â˛˙Ê˛˘Â¸ˆ‚˛˚Ë˝˘Ë˛˘Ë˛˜Ê˛¸Ó˝˚Ô˛¸Ò˝˙Í˛¸Ì˛¸Ôˇ˝˛˝ÔˇˇÒ˛˝Ô˛˝Ô˛¸Óˇ˛Òˇ˝Òˇ˝Ò˛˝Òˇ˝Ùˇ˛ˆˇ˝ˆˇ˛˜˛˝ˆˇ˛˜˝¸Ù˛ˇ˜˛ˇ˙˛˛˚˝˝˚ˇˇ˝ˇˇ˝ˇ˛¸˝˝˙˛˛˙ˇ˛˜˝˝Ùˇˇ˝ˇˇ˛ˇˇ˛˛˛˘˝˛ı˝˛ˆ
 endstream
 endobj
-373 0 obj
+375 0 obj
 <<
 /Type /Annot
 /Subtype /Widget /TU (\376\377\000A\000\040\000b\000r\000i\000g\000h\000t\000\040\000y\000e\000l\000l\000o\000w\000\040\000t\000o\000y\000\040\000m\000o\000d\000e\000l\000\040\000o\000f\000\040\000a\000\040\000c\000h\000i\000c\000k) /T (tooltip zref@1) /C [ ] /FT/Btn /F 768 /Ff 65536 /H/N /BS << /W 0 >> 
 /Rect [127.354 504 274.047 684]
 >>
 endobj
-381 0 obj
+383 0 obj
 <<
 /Type /Annot
 /Subtype /Widget /TU (\376\377\000A\000\040\000s\000e\000c\000o\000n\000d\000\040\000i\000m\000a\000g\000e\000\040\000o\000f\000\040\000a\000\040\000b\000r\000i\000g\000h\000t\000\040\000y\000e\000l\000l\000o\000w\000\040\000t\000o\000y\000\040\000m\000o\000d\000e\000l\000\040\000o\000f\000\040\000a\000\040\000c\000h\000i\000c\000k) /T (tooltip zref@2) /C [ ] /FT/Btn /F 768 /Ff 65536 /H/N /BS << /W 0 >> 
 /Rect [384.756 504 531.448 684]
 >>
 endobj
-418 0 obj
+420 0 obj
 <<
 /Type /Annot
 /Border[0 0 0]/H/I/C[0 1 1]
@@ -5959,7 +5959,7 @@ endobj
 /Subtype/Link/F 4/A<</Type/Action/S/URI/URI(https://github.com/AndyClifton/AccessibleMetaClass)>>
 >>
 endobj
-425 0 obj
+427 0 obj
 <<
 /Type /Annot
 /Border[0 0 0]/H/I/C[0 1 1]
@@ -5967,7 +5967,7 @@ endobj
 /Subtype/Link/F 4/A<</Type/Action/S/URI/URI(http://latex2rtf.sourceforge.net)>>
 >>
 endobj
-452 0 obj
+454 0 obj
 <<
 /Type /Annot
 /Border[0 0 0]/H/I/C[0 1 1]
@@ -5975,7 +5975,7 @@ endobj
 /Subtype/Link/F 4/A<</Type/Action/S/URI/URI(http://latex2rtf.sourceforge.net)>>
 >>
 endobj
-453 0 obj
+455 0 obj
 <<
 /Type /Annot
 /Border[0 0 0]/H/I/C[0 1 1]
@@ -5983,208 +5983,208 @@ endobj
 /Subtype/Link/F 4/A<</Type/Action/S/URI/URI(http://latex2rtf.sourceforge.net)>>
 >>
 endobj
-448 0 obj
-<<
-/D [409 0 R /XYZ 71 718.907 null]
->>
-endobj
-153 0 obj
-<<
-/D [409 0 R /XYZ 72 689.978 null]
->>
-endobj
-449 0 obj
-<<
-/D [409 0 R /XYZ 72 314.526 null]
->>
-endobj
 450 0 obj
 <<
-/D [409 0 R /XYZ 72 302.436 null]
+/D [411 0 R /XYZ 71 718.907 null]
+>>
+endobj
+155 0 obj
+<<
+/D [411 0 R /XYZ 72 689.978 null]
+>>
+endobj
+451 0 obj
+<<
+/D [411 0 R /XYZ 72 314.526 null]
+>>
+endobj
+452 0 obj
+<<
+/D [411 0 R /XYZ 72 302.436 null]
 >>
 endobj
 35 0 obj
 <<
-/D [409 0 R /XYZ 72 206.438 null]
+/D [411 0 R /XYZ 72 206.438 null]
 >>
 endobj
 39 0 obj
 <<
-/D [409 0 R /XYZ 72 130.763 null]
+/D [411 0 R /XYZ 72 130.763 null]
 >>
 endobj
-454 0 obj
+456 0 obj
 <<
-/D [409 0 R /XYZ 310.981 246.819 null]
+/D [411 0 R /XYZ 310.981 246.819 null]
 >>
 endobj
-455 0 obj
+457 0 obj
 <<
-/D [409 0 R /XYZ 310.981 234.73 null]
+/D [411 0 R /XYZ 310.981 234.73 null]
 >>
 endobj
-446 0 obj
+448 0 obj
 <<
  /ColorSpace 3 0 R /Pattern 2 0 R /ExtGState 1 0 R 
-/Font << /F81 144 0 R /F82 145 0 R /F79 141 0 R /F85 146 0 R /F113 451 0 R /F92 243 0 R /F91 235 0 R /F101 398 0 R /F107 402 0 R /F86 147 0 R >>
-/XObject << /Im1 370 0 R >>
+/Font << /F83 146 0 R /F84 147 0 R /F80 143 0 R /F87 148 0 R /F114 453 0 R /F94 245 0 R /F93 237 0 R /F102 400 0 R /F108 404 0 R /F88 149 0 R >>
+/XObject << /Im1 372 0 R >>
 /ProcSet [ /PDF /Text /ImageC ]
 >>
 endobj
+446 0 obj
+<</Type /StructElem /P 444 0 R /K [ <</Type /MCR /Pg 411  0 R /MCID 393>> 447 0 R <</Type /MCR /Pg 411  0 R /MCID 395>> <</Type /MCR /Pg 458 0 R /MCID 396>>] /S /LBody /Lang(EN)  >>
+endobj
 444 0 obj
-<</Type /StructElem /P 442 0 R /K [ <</Type /MCR /Pg 409  0 R /MCID 393>> 445 0 R <</Type /MCR /Pg 409  0 R /MCID 395>> <</Type /MCR /Pg 456 0 R /MCID 396>>] /S /LBody /Lang(EN)  >>
-endobj
-442 0 obj
-<</Type /StructElem /P 441 0 R  /Lang(EN)/K [ 443 0 R 444 0 R] /S /LI>>
-endobj
-458 0 obj
-<</Type /StructElem /P 457 0 R /K [ <</Type /MCR /Pg 456  0 R /MCID 397>>] /S /Lbl /Lang(EN)  >>
+<</Type /StructElem /P 443 0 R  /Lang(EN)/K [ 445 0 R 446 0 R] /S /LI>>
 endobj
 460 0 obj
-<</Type /StructElem /P 459 0 R /K <</Type /MCR /Pg 456  0 R /MCID 399>> /S /Span  /Lang(EN)  >>
-endobj
-461 0 obj
-<</Type /StructElem /P 459 0 R /K <</Type /MCR /Pg 456  0 R /MCID 401>> /S /Span  /Lang(EN)  >>
+<</Type /StructElem /P 459 0 R /K [ <</Type /MCR /Pg 458  0 R /MCID 397>>] /S /Lbl /Lang(EN)  >>
 endobj
 462 0 obj
-<</Type /StructElem /P 459 0 R /K <</Type /MCR /Pg 456  0 R /MCID 403>> /S /Span  /Lang(EN)  >>
-endobj
-459 0 obj
-<</Type /StructElem /P 457 0 R /K [ <</Type /MCR /Pg 456  0 R /MCID 398>> 460 0 R <</Type /MCR /Pg 456  0 R /MCID 400>> 461 0 R <</Type /MCR /Pg 456  0 R /MCID 402>> 462 0 R <</Type /MCR /Pg 456  0 R /MCID 404>>] /S /LBody /Lang(EN)  >>
-endobj
-457 0 obj
-<</Type /StructElem /P 441 0 R  /Lang(EN)/K [ 458 0 R 459 0 R] /S /LI>>
-endobj
-464 0 obj
-<</Type /StructElem /P 463 0 R /K [ <</Type /MCR /Pg 456  0 R /MCID 405>>] /S /Lbl /Lang(EN)  >>
-endobj
-466 0 obj
-<</Type /StructElem /P 465 0 R /K <</Type /MCR /Pg 456  0 R /MCID 407>> /S /Span  /Lang(EN)  >>
-endobj
-467 0 obj
-<</Type /StructElem /P 465 0 R /K [<</Type /MCR /Pg 456  0 R /MCID 409>> <</Type /OBJR /Obj 468 0 R>>] /S /Reference>>
-endobj
-469 0 obj
-<</Type /StructElem /P 465 0 R /K <</Type /MCR /Pg 456  0 R /MCID 411>> /S /Span  /Lang(EN)  >>
-endobj
-470 0 obj
-<</Type /StructElem /P 465 0 R /K <</Type /MCR /Pg 456  0 R /MCID 413>> /S /Span  /Lang(EN)  >>
-endobj
-471 0 obj
-<</Type /StructElem /P 465 0 R /K <</Type /MCR /Pg 456  0 R /MCID 415>> /S /Span  /Lang(EN)  >>
-endobj
-465 0 obj
-<</Type /StructElem /P 463 0 R /K [ <</Type /MCR /Pg 456  0 R /MCID 406>> 466 0 R <</Type /MCR /Pg 456  0 R /MCID 408>>467 0 R   <</Type /MCR /Pg 456  0 R /MCID 410>> 469 0 R <</Type /MCR /Pg 456  0 R /MCID 412>> 470 0 R <</Type /MCR /Pg 456  0 R /MCID 414>> 471 0 R <</Type /MCR /Pg 456  0 R /MCID 416>>] /S /LBody /Lang(EN)  >>
+<</Type /StructElem /P 461 0 R /K <</Type /MCR /Pg 458  0 R /MCID 399>> /S /Span  /Lang(EN)  >>
 endobj
 463 0 obj
-<</Type /StructElem /P 441 0 R  /Lang(EN)/K [ 464 0 R 465 0 R] /S /LI>>
+<</Type /StructElem /P 461 0 R /K <</Type /MCR /Pg 458  0 R /MCID 401>> /S /Span  /Lang(EN)  >>
 endobj
-473 0 obj
-<</Type /StructElem /P 472 0 R /K [ <</Type /MCR /Pg 456  0 R /MCID 417>>] /S /Lbl /Lang(EN)  >>
+464 0 obj
+<</Type /StructElem /P 461 0 R /K <</Type /MCR /Pg 458  0 R /MCID 403>> /S /Span  /Lang(EN)  >>
 endobj
-474 0 obj
-<</Type /StructElem /P 472 0 R /K [ <</Type /MCR /Pg 456  0 R /MCID 418>>] /S /LBody /Lang(EN)  >>
+461 0 obj
+<</Type /StructElem /P 459 0 R /K [ <</Type /MCR /Pg 458  0 R /MCID 398>> 462 0 R <</Type /MCR /Pg 458  0 R /MCID 400>> 463 0 R <</Type /MCR /Pg 458  0 R /MCID 402>> 464 0 R <</Type /MCR /Pg 458  0 R /MCID 404>>] /S /LBody /Lang(EN)  >>
+endobj
+459 0 obj
+<</Type /StructElem /P 443 0 R  /Lang(EN)/K [ 460 0 R 461 0 R] /S /LI>>
+endobj
+466 0 obj
+<</Type /StructElem /P 465 0 R /K [ <</Type /MCR /Pg 458  0 R /MCID 405>>] /S /Lbl /Lang(EN)  >>
+endobj
+468 0 obj
+<</Type /StructElem /P 467 0 R /K <</Type /MCR /Pg 458  0 R /MCID 407>> /S /Span  /Lang(EN)  >>
+endobj
+469 0 obj
+<</Type /StructElem /P 467 0 R /K [<</Type /MCR /Pg 458  0 R /MCID 409>> <</Type /OBJR /Obj 470 0 R>>] /S /Reference>>
+endobj
+471 0 obj
+<</Type /StructElem /P 467 0 R /K <</Type /MCR /Pg 458  0 R /MCID 411>> /S /Span  /Lang(EN)  >>
 endobj
 472 0 obj
-<</Type /StructElem /P 441 0 R  /Lang(EN)/K [ 473 0 R 474 0 R] /S /LI>>
+<</Type /StructElem /P 467 0 R /K <</Type /MCR /Pg 458  0 R /MCID 413>> /S /Span  /Lang(EN)  >>
 endobj
-441 0 obj
-<</Type /StructElem /P 419 0 R  /Lang(EN)/K [ 442 0 R 457 0 R 463 0 R 472 0 R] /S /L1>>
+473 0 obj
+<</Type /StructElem /P 467 0 R /K <</Type /MCR /Pg 458  0 R /MCID 415>> /S /Span  /Lang(EN)  >>
 endobj
-419 0 obj
-<</Type /StructElem /P 191 0 R /T (Changing to a WYSIWYG-readable format using Latex2rtf) /Lang(EN)/K [ 420 0 R 421 0 R 426 0 R 435 0 R 436 0 R 437 0 R 439 0 R 441 0 R] /S /Subsection>>
+467 0 obj
+<</Type /StructElem /P 465 0 R /K [ <</Type /MCR /Pg 458  0 R /MCID 406>> 468 0 R <</Type /MCR /Pg 458  0 R /MCID 408>>469 0 R   <</Type /MCR /Pg 458  0 R /MCID 410>> 471 0 R <</Type /MCR /Pg 458  0 R /MCID 412>> 472 0 R <</Type /MCR /Pg 458  0 R /MCID 414>> 473 0 R <</Type /MCR /Pg 458  0 R /MCID 416>>] /S /LBody /Lang(EN)  >>
 endobj
-191 0 obj
-<</Type /StructElem /P 62 0 R /T (A workflow for producing accessible .pdf files) /Lang(EN)/K [ 192 0 R 193 0 R 194 0 R 221 0 R 222 0 R 223 0 R 352 0 R 414 0 R 419 0 R] /S /Section>>
+465 0 obj
+<</Type /StructElem /P 443 0 R  /Lang(EN)/K [ 466 0 R 467 0 R] /S /LI>>
+endobj
+475 0 obj
+<</Type /StructElem /P 474 0 R /K [ <</Type /MCR /Pg 458  0 R /MCID 417>>] /S /Lbl /Lang(EN)  >>
 endobj
 476 0 obj
-<</Type /StructElem /P 475 0 R /K [ <</Type /MCR /Pg 456  0 R /MCID 419>>] /S /H /Lang(EN)  >>
+<</Type /StructElem /P 474 0 R /K [ <</Type /MCR /Pg 458  0 R /MCID 418>>] /S /LBody /Lang(EN)  >>
 endobj
-477 0 obj
-<</Type /StructElem /P 475 0 R /K [ <</Type /MCR /Pg 456  0 R /MCID 420>>] /S /P /Lang(EN)>>
+474 0 obj
+<</Type /StructElem /P 443 0 R  /Lang(EN)/K [ 475 0 R 476 0 R] /S /LI>>
 endobj
-480 0 obj
-<</Type /StructElem /P 479 0 R /K [ <</Type /MCR /Pg 456  0 R /MCID 421>>] /S /Lbl /Lang(EN)  >>
+443 0 obj
+<</Type /StructElem /P 421 0 R  /Lang(EN)/K [ 444 0 R 459 0 R 465 0 R 474 0 R] /S /L1>>
 endobj
-482 0 obj
-<</Type /StructElem /P 481 0 R /K <</Type /MCR /Pg 456  0 R /MCID 423>> /S /Span  /Lang(EN)  >>
+421 0 obj
+<</Type /StructElem /P 193 0 R /T (Changing to a WYSIWYG-readable format using Latex2rtf) /Lang(EN)/K [ 422 0 R 423 0 R 428 0 R 437 0 R 438 0 R 439 0 R 441 0 R 443 0 R] /S /Subsection>>
 endobj
-481 0 obj
-<</Type /StructElem /P 479 0 R /K [ <</Type /MCR /Pg 456  0 R /MCID 422>> 482 0 R <</Type /MCR /Pg 456  0 R /MCID 424>>] /S /LBody /Lang(EN)  >>
-endobj
-479 0 obj
-<</Type /StructElem /P 478 0 R  /Lang(EN)/K [ 480 0 R 481 0 R] /S /LI>>
-endobj
-484 0 obj
-<</Type /StructElem /P 483 0 R /K [ <</Type /MCR /Pg 456  0 R /MCID 425>>] /S /Lbl /Lang(EN)  >>
-endobj
-486 0 obj
-<</Type /StructElem /P 485 0 R /K <</Type /MCR /Pg 456  0 R /MCID 427>> /S /Span  /Lang(EN)  >>
-endobj
-485 0 obj
-<</Type /StructElem /P 483 0 R /K [ <</Type /MCR /Pg 456  0 R /MCID 426>> 486 0 R <</Type /MCR /Pg 456  0 R /MCID 428>>] /S /LBody /Lang(EN)  >>
-endobj
-483 0 obj
-<</Type /StructElem /P 478 0 R  /Lang(EN)/K [ 484 0 R 485 0 R] /S /LI>>
+193 0 obj
+<</Type /StructElem /P 64 0 R /T (A workflow for producing accessible .pdf files) /Lang(EN)/K [ 194 0 R 195 0 R 196 0 R 223 0 R 224 0 R 225 0 R 354 0 R 416 0 R 421 0 R] /S /Section>>
 endobj
 478 0 obj
-<</Type /StructElem /P 475 0 R  /Lang(EN)/K [ 479 0 R 483 0 R] /S /L1>>
+<</Type /StructElem /P 477 0 R /K [ <</Type /MCR /Pg 458  0 R /MCID 419>>] /S /H /Lang(EN)  >>
 endobj
-487 0 obj
-<</Type /StructElem /P 475 0 R /K [ <</Type /MCR /Pg 456  0 R /MCID 429>>] /S /P /Lang(EN)>>
+479 0 obj
+<</Type /StructElem /P 477 0 R /K [ <</Type /MCR /Pg 458  0 R /MCID 420>>] /S /P /Lang(EN)>>
 endobj
-489 0 obj
-<</Type /StructElem /P 488 0 R /K <</Type /MCR /Pg 456  0 R /MCID 431>> /S /Span  /Lang(EN)  >>
+482 0 obj
+<</Type /StructElem /P 481 0 R /K [ <</Type /MCR /Pg 458  0 R /MCID 421>>] /S /Lbl /Lang(EN)  >>
 endobj
-490 0 obj
-<</Type /StructElem /P 488 0 R /K <</Type /MCR /Pg 456  0 R /MCID 433>> /S /Span  /Lang(EN)  >>
+484 0 obj
+<</Type /StructElem /P 483 0 R /K <</Type /MCR /Pg 458  0 R /MCID 423>> /S /Span  /Lang(EN)  >>
+endobj
+483 0 obj
+<</Type /StructElem /P 481 0 R /K [ <</Type /MCR /Pg 458  0 R /MCID 422>> 484 0 R <</Type /MCR /Pg 458  0 R /MCID 424>>] /S /LBody /Lang(EN)  >>
+endobj
+481 0 obj
+<</Type /StructElem /P 480 0 R  /Lang(EN)/K [ 482 0 R 483 0 R] /S /LI>>
+endobj
+486 0 obj
+<</Type /StructElem /P 485 0 R /K [ <</Type /MCR /Pg 458  0 R /MCID 425>>] /S /Lbl /Lang(EN)  >>
 endobj
 488 0 obj
-<</Type /StructElem /P 475 0 R /K [ <</Type /MCR /Pg 456  0 R /MCID 430>> 489 0 R <</Type /MCR /Pg 456  0 R /MCID 432>> 490 0 R <</Type /MCR /Pg 456  0 R /MCID 434>>] /S /P /Lang(EN)>>
+<</Type /StructElem /P 487 0 R /K <</Type /MCR /Pg 458  0 R /MCID 427>> /S /Span  /Lang(EN)  >>
+endobj
+487 0 obj
+<</Type /StructElem /P 485 0 R /K [ <</Type /MCR /Pg 458  0 R /MCID 426>> 488 0 R <</Type /MCR /Pg 458  0 R /MCID 428>>] /S /LBody /Lang(EN)  >>
+endobj
+485 0 obj
+<</Type /StructElem /P 480 0 R  /Lang(EN)/K [ 486 0 R 487 0 R] /S /LI>>
+endobj
+480 0 obj
+<</Type /StructElem /P 477 0 R  /Lang(EN)/K [ 481 0 R 485 0 R] /S /L1>>
+endobj
+489 0 obj
+<</Type /StructElem /P 477 0 R /K [ <</Type /MCR /Pg 458  0 R /MCID 429>>] /S /P /Lang(EN)>>
 endobj
 491 0 obj
-<</Type /StructElem /P 475 0 R /K [ <</Type /MCR /Pg 456  0 R /MCID 435>> <</Type /MCR /Pg 456  0 R /MCID 436>> <</Type /MCR /Pg 456  0 R /MCID 437>> <</Type /MCR /Pg 456  0 R /MCID 438>> <</Type /MCR /Pg 456  0 R /MCID 439>> <</Type /MCR /Pg 456  0 R /MCID 440>> <</Type /MCR /Pg 456  0 R /MCID 441>> <</Type /MCR /Pg 456  0 R /MCID 442>>] /S /Code /Lang(EN)  >>
-endobj
-493 0 obj
-<</Type /StructElem /P 492 0 R /K [ <</Type /MCR /Pg 456 0 R /MCID 443>> <</Type /MCR /Pg 456  0 R /MCID 444>>] /S /H /Lang(EN)  >>
-endobj
-495 0 obj
-<</Type /StructElem /P 494 0 R /K <</Type /MCR /Pg 456  0 R /MCID 446>> /S /Span  /Lang(EN)  >>
-endobj
-496 0 obj
-<</Type /StructElem /P 494 0 R /K <</Type /MCR /Pg 456  0 R /MCID 448>> /S /Span  /Lang(EN)  >>
-endobj
-497 0 obj
-<</Type /StructElem /P 494 0 R /K <</Type /MCR /Pg 456  0 R /MCID 450>> /S /Span  /Lang(EN)  >>
-endobj
-498 0 obj
-<</Type /StructElem /P 494 0 R /K <</Type /MCR /Pg 456  0 R /MCID 452>> /S /Span  /Lang(EN)  >>
-endobj
-499 0 obj
-<</Type /StructElem /P 494 0 R /K <</Type /MCR /Pg 456  0 R /MCID 454>> /S /Span  /Lang(EN)  >>
-endobj
-494 0 obj
-<</Type /StructElem /P 492 0 R /K [ <</Type /MCR /Pg 456  0 R /MCID 445>> 495 0 R <</Type /MCR /Pg 456  0 R /MCID 447>> 496 0 R <</Type /MCR /Pg 456  0 R /MCID 449>> 497 0 R <</Type /MCR /Pg 456  0 R /MCID 451>> 498 0 R <</Type /MCR /Pg 456  0 R /MCID 453>> 499 0 R <</Type /MCR /Pg 456  0 R /MCID 455>>] /S /P /Lang(EN)>>
-endobj
-501 0 obj
-<</Type /StructElem /P 500 0 R /K <</Type /MCR /Pg 456  0 R /MCID 457>> /S /Span  /Lang(EN)  >>
-endobj
-502 0 obj
-<</Type /StructElem /P 500 0 R /K <</Type /MCR /Pg 456  0 R /MCID 459>> /S /Span  /Lang(EN)  >>
-endobj
-500 0 obj
-<</Type /StructElem /P 492 0 R /K [ <</Type /MCR /Pg 456  0 R /MCID 456>> 501 0 R <</Type /MCR /Pg 456  0 R /MCID 458>> 502 0 R <</Type /MCR /Pg 456  0 R /MCID 460>>] /S /P /Lang(EN)>>
-endobj
-503 0 obj
-<</Type /StructElem /P 492 0 R /K [ <</Type /MCR /Pg 456  0 R /MCID 461>> <</Type /MCR /Pg 456  0 R /MCID 462>> <</Type /MCR /Pg 456  0 R /MCID 463>> <</Type /MCR /Pg 456  0 R /MCID 464>> <</Type /MCR /Pg 456  0 R /MCID 465>> <</Type /MCR /Pg 456  0 R /MCID 466>> <</Type /MCR /Pg 456  0 R /MCID 467>> <</Type /MCR /Pg 456  0 R /MCID 468>> <</Type /MCR /Pg 456  0 R /MCID 469>>] /S /Code /Lang(EN)  >>
+<</Type /StructElem /P 490 0 R /K <</Type /MCR /Pg 458  0 R /MCID 431>> /S /Span  /Lang(EN)  >>
 endobj
 492 0 obj
-<</Type /StructElem /P 475 0 R /T (Including code listings) /Lang(EN)/K [ 493 0 R 494 0 R 500 0 R 503 0 R] /S /Subsection>>
+<</Type /StructElem /P 490 0 R /K <</Type /MCR /Pg 458  0 R /MCID 433>> /S /Span  /Lang(EN)  >>
+endobj
+490 0 obj
+<</Type /StructElem /P 477 0 R /K [ <</Type /MCR /Pg 458  0 R /MCID 430>> 491 0 R <</Type /MCR /Pg 458  0 R /MCID 432>> 492 0 R <</Type /MCR /Pg 458  0 R /MCID 434>>] /S /P /Lang(EN)>>
+endobj
+493 0 obj
+<</Type /StructElem /P 477 0 R /K [ <</Type /MCR /Pg 458  0 R /MCID 435>> <</Type /MCR /Pg 458  0 R /MCID 436>> <</Type /MCR /Pg 458  0 R /MCID 437>> <</Type /MCR /Pg 458  0 R /MCID 438>> <</Type /MCR /Pg 458  0 R /MCID 439>> <</Type /MCR /Pg 458  0 R /MCID 440>> <</Type /MCR /Pg 458  0 R /MCID 441>> <</Type /MCR /Pg 458  0 R /MCID 442>>] /S /Code /Lang(EN)  >>
+endobj
+495 0 obj
+<</Type /StructElem /P 494 0 R /K [ <</Type /MCR /Pg 458 0 R /MCID 443>> <</Type /MCR /Pg 458  0 R /MCID 444>>] /S /H /Lang(EN)  >>
+endobj
+497 0 obj
+<</Type /StructElem /P 496 0 R /K <</Type /MCR /Pg 458  0 R /MCID 446>> /S /Span  /Lang(EN)  >>
+endobj
+498 0 obj
+<</Type /StructElem /P 496 0 R /K <</Type /MCR /Pg 458  0 R /MCID 448>> /S /Span  /Lang(EN)  >>
+endobj
+499 0 obj
+<</Type /StructElem /P 496 0 R /K <</Type /MCR /Pg 458  0 R /MCID 450>> /S /Span  /Lang(EN)  >>
+endobj
+500 0 obj
+<</Type /StructElem /P 496 0 R /K <</Type /MCR /Pg 458  0 R /MCID 452>> /S /Span  /Lang(EN)  >>
+endobj
+501 0 obj
+<</Type /StructElem /P 496 0 R /K <</Type /MCR /Pg 458  0 R /MCID 454>> /S /Span  /Lang(EN)  >>
+endobj
+496 0 obj
+<</Type /StructElem /P 494 0 R /K [ <</Type /MCR /Pg 458  0 R /MCID 445>> 497 0 R <</Type /MCR /Pg 458  0 R /MCID 447>> 498 0 R <</Type /MCR /Pg 458  0 R /MCID 449>> 499 0 R <</Type /MCR /Pg 458  0 R /MCID 451>> 500 0 R <</Type /MCR /Pg 458  0 R /MCID 453>> 501 0 R <</Type /MCR /Pg 458  0 R /MCID 455>>] /S /P /Lang(EN)>>
+endobj
+503 0 obj
+<</Type /StructElem /P 502 0 R /K <</Type /MCR /Pg 458  0 R /MCID 457>> /S /Span  /Lang(EN)  >>
+endobj
+504 0 obj
+<</Type /StructElem /P 502 0 R /K <</Type /MCR /Pg 458  0 R /MCID 459>> /S /Span  /Lang(EN)  >>
+endobj
+502 0 obj
+<</Type /StructElem /P 494 0 R /K [ <</Type /MCR /Pg 458  0 R /MCID 456>> 503 0 R <</Type /MCR /Pg 458  0 R /MCID 458>> 504 0 R <</Type /MCR /Pg 458  0 R /MCID 460>>] /S /P /Lang(EN)>>
 endobj
 505 0 obj
-<</Type /StructElem /P 504 0 R /K [ <</Type /MCR /Pg 456  0 R /MCID 470>>] /S /H /Lang(EN)  >>
+<</Type /StructElem /P 494 0 R /K [ <</Type /MCR /Pg 458  0 R /MCID 461>> <</Type /MCR /Pg 458  0 R /MCID 462>> <</Type /MCR /Pg 458  0 R /MCID 463>> <</Type /MCR /Pg 458  0 R /MCID 464>> <</Type /MCR /Pg 458  0 R /MCID 465>> <</Type /MCR /Pg 458  0 R /MCID 466>> <</Type /MCR /Pg 458  0 R /MCID 467>> <</Type /MCR /Pg 458  0 R /MCID 468>> <</Type /MCR /Pg 458  0 R /MCID 469>>] /S /Code /Lang(EN)  >>
 endobj
-508 0 obj
+494 0 obj
+<</Type /StructElem /P 477 0 R /T (Including code listings) /Lang(EN)/K [ 495 0 R 496 0 R 502 0 R 505 0 R] /S /Subsection>>
+endobj
+507 0 obj
+<</Type /StructElem /P 506 0 R /K [ <</Type /MCR /Pg 458  0 R /MCID 470>>] /S /H /Lang(EN)  >>
+endobj
+510 0 obj
 <<
 /Length 48211     
 >>
@@ -6195,24 +6195,24 @@ stream
 /P <</MCID 396>> BDC
 1 0 0 1 -72 -684 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 91.925 674.037 Td [(con)40(v)15(erts)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.696 0 Td [(using)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 91.925 674.037 Td [(con)40(v)15(erts)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.696 0 Td [(using)]TJ
 ET
 1 0 0 1 151.701 674.037 cm
 EMC
 /Span <</MCID 394>> BDC
 1 0 0 1 -151.701 -674.037 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 151.701 674.037 Td [(latex2rtf)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 151.701 674.037 Td [(latex2rtf)]TJ
 ET
 1 0 0 1 187.695 674.037 cm
 EMC
 /LBody <</MCID 395>> BDC
 1 0 0 1 -187.695 -674.037 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 190.186 674.037 Td [(e)25(v)15(ery)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.219 0 Td [(time)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(you)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(use)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.771 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(ne)25(w)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 190.186 674.037 Td [(e)25(v)15(ery)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.219 0 Td [(time)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(you)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(use)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.771 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(ne)25(w)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -182.803 -11.955 Td [(en)40(vironment.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -182.803 -11.955 Td [(en)40(vironment.)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -6222,7 +6222,7 @@ EMC
 /Lbl <</MCID 397>> BDC
 1 0 0 1 -67.019 -643.978 cm
 BT
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 74.491 643.978 Td [(Check)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 29.608 0 Td [(new)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 19.647 0 Td [(packages.)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 74.491 643.978 Td [(Check)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 29.608 0 Td [(new)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 19.647 0 Td [(packages.)]TJ
 ET
 1 0 0 1 168.069 643.978 cm
 EMC
@@ -6231,7 +6231,7 @@ EMC
 /LBody <</MCID 398>> BDC
 1 0 0 1 -173.05 -643.978 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 173.05 643.978 Td [(If)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.126 0 Td [(you)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(add)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(ne)25(w)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.839 0 Td [(package)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.129 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(the)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 173.05 643.978 Td [(If)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.126 0 Td [(you)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(add)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(ne)25(w)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.839 0 Td [(package)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.129 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(the)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -6240,63 +6240,63 @@ EMC
 /Span <</MCID 399>> BDC
 1 0 0 1 -91.925 -632.023 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 91.925 632.023 Td [(meta.cls)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 91.925 632.023 Td [(meta.cls)]TJ
 ET
 1 0 0 1 124.851 632.023 cm
 EMC
 /LBody <</MCID 400>> BDC
 1 0 0 1 -124.851 -632.023 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 127.342 632.023 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(\050not)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.54 0 Td [(recommended\051,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 64.737 0 Td [(try)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 13.559 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(con)40(v)15(ersion)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 127.342 632.023 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(\050not)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.54 0 Td [(recommended\051,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 64.737 0 Td [(try)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 13.559 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(con)40(v)15(ersion)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -162.141 -11.956 Td [(immediately)65(,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 54.147 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(then)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.646 0 Td [(ag)5(ain)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.02 0 Td [(once)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(you)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(actually)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -162.141 -11.956 Td [(immediately)65(,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 54.147 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(then)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.646 0 Td [(ag)5(ain)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.02 0 Td [(once)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(you)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(actually)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -153.424 -11.955 Td [(use)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.771 0 Td [(one)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(ne)25(w)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.839 0 Td [(en)40(vironments)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 56.329 0 Td [(or)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(commands.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 48.747 0 Td [(If)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -153.424 -11.955 Td [(use)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.771 0 Td [(one)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(ne)25(w)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.839 0 Td [(en)40(vironments)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 56.329 0 Td [(or)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(commands.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 48.747 0 Td [(If)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -192.806 -11.955 Td [(you')50(v)15(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 29.51 0 Td [(added)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.281 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(ne)25(w)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.839 0 Td [(package)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.128 0 Td [(that)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -192.806 -11.955 Td [(you')50(v)15(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 29.51 0 Td [(added)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.281 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(ne)25(w)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.839 0 Td [(package)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.128 0 Td [(that)]TJ
 ET
 1 0 0 1 226.032 596.157 cm
 EMC
 /Span <</MCID 401>> BDC
 1 0 0 1 -226.032 -596.157 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 226.032 596.157 Td [(latex2rtf)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 226.032 596.157 Td [(latex2rtf)]TJ
 ET
 1 0 0 1 262.026 596.157 cm
 EMC
 /LBody <</MCID 402>> BDC
 1 0 0 1 -262.026 -596.157 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 264.517 596.157 Td [(doesn')18(t)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 264.517 596.157 Td [(doesn')18(t)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -172.592 -11.955 Td [(support,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.869 0 Td [(you)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(may)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.646 0 Td [(need)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(edit)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(\002le)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -172.592 -11.955 Td [(support,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.869 0 Td [(you)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(may)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.646 0 Td [(need)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(edit)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(\002le)]TJ
 ET
 1 0 0 1 242.738 584.202 cm
 EMC
 /Span <</MCID 403>> BDC
 1 0 0 1 -242.738 -584.202 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 242.738 584.202 Td [(Late)20(x2rtf_-)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 242.738 584.202 Td [(Late)20(x2rtf_-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F85 9.9626 Tf -150.813 -11.955 Td [(meta_with_acc.te)20(x)]TJ
+/F84 1 Tf( )Tj/F87 9.9626 Tf -150.813 -11.955 Td [(meta_with_acc.te)20(x)]TJ
 ET
 1 0 0 1 166.186 572.247 cm
 EMC
 /LBody <</MCID 404>> BDC
 1 0 0 1 -166.186 -572.247 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 168.677 572.247 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(rede\002ne)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.58 0 Td [(those)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.522 0 Td [(commands)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.658 0 Td [(to)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 168.677 572.247 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(rede\002ne)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.58 0 Td [(those)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.522 0 Td [(commands)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.658 0 Td [(to)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -190.753 -11.955 Td [(something)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.005 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(will)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.992 0 Td [(get)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(you)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(through)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 33.484 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(con)40(v)15(ersion)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -190.753 -11.955 Td [(something)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.005 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(will)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.992 0 Td [(get)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(you)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(through)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 33.484 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(con)40(v)15(ersion)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -159.68 -11.956 Td [(\050and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.194 0 Td [(re)25(vie)25(w\051.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -159.68 -11.956 Td [(\050and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.194 0 Td [(re)25(vie)25(w\051.)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -6306,7 +6306,7 @@ EMC
 /Lbl <</MCID 405>> BDC
 1 0 0 1 -67.019 -530.232 cm
 BT
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 74.491 530.232 Td [(A)100(v)10(oid)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 26.859 0 Td [(custom)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 32.926 0 Td [(commands.)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 74.491 530.232 Td [(A)100(v)10(oid)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 26.859 0 Td [(custom)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 32.926 0 Td [(commands.)]TJ
 ET
 1 0 0 1 185.792 530.232 cm
 EMC
@@ -6317,20 +6317,20 @@ EMC
 /Span <</MCID 407>> BDC
 1 0 0 1 -190.774 -530.232 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 190.774 530.232 Td [(latex2rtf)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 190.774 530.232 Td [(latex2rtf)]TJ
 ET
 1 0 0 1 226.768 530.232 cm
 EMC
 /LBody <</MCID 408>> BDC
 1 0 0 1 -226.768 -530.232 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 229.259 530.232 Td [(does)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(not)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(w)10(ork)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 229.259 530.232 Td [(does)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(not)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(w)10(ork)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -173.309 -11.955 Td [(well)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.646 0 Td [(with)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(custom)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.273 0 Td [(commands.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 48.746 0 Td [(A)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(list)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.675 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(all)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(rec-)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -173.309 -11.955 Td [(well)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.646 0 Td [(with)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(custom)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.273 0 Td [(commands.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 48.746 0 Td [(A)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(list)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.675 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(all)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(rec-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -167.47 -11.955 Td [(ognized)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.032 0 Td [(commands)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.659 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.135 0 Td [(a)20(v)25(ailable)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.007 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(manual)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.82 0 Td [(at)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -167.47 -11.955 Td [(ognized)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.032 0 Td [(commands)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.659 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.135 0 Td [(a)20(v)25(ailable)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.007 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(manual)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.82 0 Td [(at)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -6340,10 +6340,10 @@ EMC
 0 g 0 G
 1 0 0 1 -91.925 -494.366 cm
 BT
-/F101 9.9626 Tf/F82 1 Tf( )Tj/F101 9.9626 Tf 91.925 494.366 Td [(http://latex2rtf.sourceforge.net/)]TJ
+/F102 9.9626 Tf/F84 1 Tf( )Tj/F102 9.9626 Tf 91.925 494.366 Td [(http://latex2rtf.sourceforge.net/)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F101 9.9626 Tf 0 -11.955 Td [(latex2rtf.pdf)]TJ
+/F84 1 Tf( )Tj/F102 9.9626 Tf 0 -11.955 Td [(latex2rtf.pdf)]TJ
 0 g 0 G
 ET
 1 0 0 1 169.634 482.411 cm
@@ -6351,67 +6351,67 @@ EMC
 /LBody <</MCID 410>> BDC
 1 0 0 1 -169.634 -482.411 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 169.634 482.411 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 5.579 0 Td [(If)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.126 0 Td [(you)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(ha)20(v)15(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.952 0 Td [(custom)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.272 0 Td [(commands,)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 169.634 482.411 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 5.579 0 Td [(If)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.126 0 Td [(you)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(ha)20(v)15(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.952 0 Td [(custom)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.272 0 Td [(commands,)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -162.072 -11.955 Td [(you)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(may)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.646 0 Td [(need)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(rede\002ne)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.58 0 Td [(those)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.521 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(w)10(ork)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.864 0 Td [(with)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -162.072 -11.955 Td [(you)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(may)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.646 0 Td [(need)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(rede\002ne)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.58 0 Td [(those)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.521 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(w)10(ork)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.864 0 Td [(with)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(the)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -180.034 -11.955 Td [(commands)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.659 0 Td [(that)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -180.034 -11.955 Td [(commands)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.659 0 Td [(that)]TJ
 ET
 1 0 0 1 155.018 458.501 cm
 EMC
 /Span <</MCID 411>> BDC
 1 0 0 1 -155.018 -458.501 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 155.018 458.501 Td [(latex2rtf)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 155.018 458.501 Td [(latex2rtf)]TJ
 ET
 1 0 0 1 191.012 458.501 cm
 EMC
 /LBody <</MCID 412>> BDC
 1 0 0 1 -191.012 -458.501 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 193.503 458.501 Td [(does)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(recognize,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 43.706 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(place)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 193.503 458.501 Td [(does)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(recognize,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 43.706 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(place)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -182.912 -11.955 Td [(these)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.964 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(preamble.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 42.65 0 Td [(T)80(o)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.762 0 Td [(separate)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.128 0 Td [(your)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(commands)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -182.912 -11.955 Td [(these)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.964 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(preamble.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 42.65 0 Td [(T)80(o)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.762 0 Td [(separate)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.128 0 Td [(your)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(commands)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -159.162 -11.955 Td [(from)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(those)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.522 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(required)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.686 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(compatibility)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 55.63 0 Td [(with)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -159.162 -11.955 Td [(from)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(those)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.522 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(required)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.686 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(compatibility)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 55.63 0 Td [(with)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -182.892 -11.956 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -182.892 -11.956 Td [(the)]TJ
 ET
 1 0 0 1 106.59 422.635 cm
 EMC
 /Span <</MCID 413>> BDC
 1 0 0 1 -106.59 -422.635 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 106.59 422.635 Td [(meta)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 106.59 422.635 Td [(meta)]TJ
 ET
 1 0 0 1 126.515 422.635 cm
 EMC
 /LBody <</MCID 414>> BDC
 1 0 0 1 -126.515 -422.635 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 129.006 422.635 Td [(class,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.348 0 Td [(place)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.512 0 Td [(your)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(commands)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.658 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(separate)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 129.006 422.635 Td [(class,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.348 0 Td [(place)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.512 0 Td [(your)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(commands)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.658 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(separate)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -168.507 -11.955 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(\050e.g)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -168.507 -11.955 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(\050e.g)]TJ
 ET
 1 0 0 1 124.851 410.68 cm
 EMC
 /Span <</MCID 415>> BDC
 1 0 0 1 -124.851 -410.68 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 124.851 410.68 Td [(Late)20(x2rtf_meta_with_acc_CUST)18(OM.te)20(x)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 124.851 410.68 Td [(Late)20(x2rtf_meta_with_acc_CUST)18(OM.te)20(x)]TJ
 ET
 1 0 0 1 285.079 410.68 cm
 EMC
 /LBody <</MCID 416>> BDC
 1 0 0 1 -285.079 -410.68 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 285.079 410.68 Td [(\051.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 285.079 410.68 Td [(\051.)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -6421,7 +6421,7 @@ EMC
 /Lbl <</MCID 417>> BDC
 1 0 0 1 -67.019 -392.576 cm
 BT
-/F86 9.9626 Tf/F82 1 Tf( )Tj/F86 9.9626 Tf 74.491 392.576 Td [(Remo)10(v)10(e)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 36.592 0 Td [(all)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 13.011 0 Td [(of)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 10.79 0 Td [(y)25(our)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 22.166 0 Td [(to-do)]TJ/F82 1 Tf( )Tj/F86 9.9626 Tf 24.628 0 Td [(notes.)]TJ
+/F88 9.9626 Tf/F84 1 Tf( )Tj/F88 9.9626 Tf 74.491 392.576 Td [(Remo)10(v)10(e)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 36.592 0 Td [(all)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 13.011 0 Td [(of)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 10.79 0 Td [(y)25(our)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 22.166 0 Td [(to-do)]TJ/F84 1 Tf( )Tj/F88 9.9626 Tf 24.628 0 Td [(notes.)]TJ
 ET
 1 0 0 1 209.394 392.576 cm
 EMC
@@ -6430,10 +6430,10 @@ EMC
 /LBody <</MCID 418>> BDC
 1 0 0 1 -214.375 -392.576 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 214.375 392.576 Td [(W)80(e')50(v)15(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.597 0 Td [(all)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.453 0 Td [(for)18(gotten)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.834 0 Td [(to)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 214.375 392.576 Td [(W)80(e')50(v)15(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.597 0 Td [(all)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.453 0 Td [(for)18(gotten)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.834 0 Td [(to)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -201.334 -11.955 Td [(do)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 12.454 0 Td [(this)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.886 0 Td [(at)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.683 0 Td [(one)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(time)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(or)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(another)55(...)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -201.334 -11.955 Td [(do)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 12.454 0 Td [(this)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.886 0 Td [(at)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.683 0 Td [(one)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(time)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(or)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(another)55(...)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -6444,7 +6444,7 @@ EMC
 /H <</MCID 419>> BDC
 1 0 0 1 -72 -345.567 cm
 BT
-/F81 11.9552 Tf/F82 1 Tf( )Tj/F81 11.9552 Tf 72 345.567 Td [(4)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 18.602 0 Td [(Uni\002ed)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 43.839 0 Td [(sour)20(ce)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 42.285 0 Td [(document)]TJ
+/F83 11.9552 Tf/F84 1 Tf( )Tj/F83 11.9552 Tf 72 345.567 Td [(4)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 18.602 0 Td [(Uni\002ed)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 43.839 0 Td [(sour)20(ce)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 42.285 0 Td [(document)]TJ
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 g 0 G
@@ -6455,10 +6455,10 @@ EMC
 /P <</MCID 420>> BDC
 1 0 0 1 -72 -326.265 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 326.265 Td [(So)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 13.011 0 Td [(f)10(ar)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 13.45 0 Td [(we)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(ha)20(v)15(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.951 0 Td [(identi\002ed)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 40.129 0 Td [(tw)10(o)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.335 0 Td [(discrete)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 33.474 0 Td [(paths)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.521 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(our)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 326.265 Td [(So)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 13.011 0 Td [(f)10(ar)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 13.45 0 Td [(we)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(ha)20(v)15(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.951 0 Td [(identi\002ed)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 40.129 0 Td [(tw)10(o)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.335 0 Td [(discrete)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 33.474 0 Td [(paths)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.521 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(our)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -193.413 -11.955 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(will)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.992 0 Td [(tak)10(e.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.077 0 Td [(These)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.281 0 Td [(are)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -193.413 -11.955 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(will)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.992 0 Td [(tak)10(e.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.077 0 Td [(These)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.281 0 Td [(are)]TJ
 ET
 1 0 0 1 194.788 314.31 cm
 EMC
@@ -6469,7 +6469,7 @@ EMC
 /Lbl <</MCID 421>> BDC
 1 0 0 1 -76.981 -296.205 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 79.472 296.205 Td [(1.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 79.472 296.205 Td [(1.)]TJ
 ET
 1 0 0 1 86.944 296.205 cm
 EMC
@@ -6478,14 +6478,14 @@ EMC
 /LBody <</MCID 422>> BDC
 1 0 0 1 -91.925 -296.205 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 91.925 296.205 Td [(Compiling)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 45.121 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.664 0 Td [(L)]TJ/F79 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.427 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.683 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.08 0 Td [(normal)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 91.925 296.205 Td [(Compiling)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 45.121 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.664 0 Td [(L)]TJ/F80 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.427 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.683 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.08 0 Td [(normal)]TJ
 ET
 1 0 0 1 273.568 296.205 cm
 EMC
 /Span <</MCID 423>> BDC
 1 0 0 1 -273.568 -296.205 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 273.568 296.205 Td [(pdftex)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 273.568 296.205 Td [(pdftex)]TJ
 ET
 1 0 0 1 299.023 296.205 cm
 EMC
@@ -6498,7 +6498,7 @@ EMC
 /Lbl <</MCID 425>> BDC
 1 0 0 1 -76.981 -278.101 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 79.472 278.101 Td [(2.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 79.472 278.101 Td [(2.)]TJ
 ET
 1 0 0 1 86.944 278.101 cm
 EMC
@@ -6507,21 +6507,21 @@ EMC
 /LBody <</MCID 426>> BDC
 1 0 0 1 -91.925 -278.101 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 91.925 278.101 Td [(Con)40(v)15(erting)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 46.775 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(something)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.005 0 Td [(portable)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.138 0 Td [(using)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 91.925 278.101 Td [(Con)40(v)15(erting)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 46.775 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(something)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.005 0 Td [(portable)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.138 0 Td [(using)]TJ
 ET
 1 0 0 1 252.163 278.101 cm
 EMC
 /Span <</MCID 427>> BDC
 1 0 0 1 -252.163 -278.101 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 252.163 278.101 Td [(latex2rtf)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 252.163 278.101 Td [(latex2rtf)]TJ
 ET
 1 0 0 1 288.157 278.101 cm
 EMC
 /LBody <</MCID 428>> BDC
 1 0 0 1 -288.157 -278.101 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 288.157 278.101 Td [(.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 288.157 278.101 Td [(.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -6531,10 +6531,10 @@ EMC
 /P <</MCID 429>> BDC
 1 0 0 1 -72 -259.996 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 259.996 Td [(And,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.137 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(k)10(eep)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.201 0 Td [(things)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.849 0 Td [(tidy)65(,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.835 0 Td [(we)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(w)10(ould)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.298 0 Td [(lik)10(e)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.335 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(use)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.771 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(same)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 259.996 Td [(And,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.137 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(k)10(eep)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.201 0 Td [(things)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.849 0 Td [(tidy)65(,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.835 0 Td [(we)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(w)10(ould)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.298 0 Td [(lik)10(e)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.335 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(use)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.771 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(same)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -199.68 -11.955 Td [(source)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.493 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(each)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.742 0 Td [(step.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -199.68 -11.955 Td [(source)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.493 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(each)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.742 0 Td [(step.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -6543,44 +6543,44 @@ EMC
 /P <</MCID 430>> BDC
 1 0 0 1 -72 -229.937 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 229.937 Td [(F)15(ortunately)65(,)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 229.937 Td [(F)15(ortunately)65(,)]TJ
 ET
 1 0 0 1 122.122 229.937 cm
 EMC
 /Span <</MCID 431>> BDC
 1 0 0 1 -122.122 -229.937 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 122.122 229.937 Td [(latex2rtf)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 122.122 229.937 Td [(latex2rtf)]TJ
 ET
 1 0 0 1 158.116 229.937 cm
 EMC
 /P <</MCID 432>> BDC
 1 0 0 1 -158.116 -229.937 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 160.607 229.937 Td [(of)25(fers)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.474 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(boolean,)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 160.607 229.937 Td [(of)25(fers)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.474 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(boolean,)]TJ
 0 g 0 G
 0 g 0 G
-/F107 9.9626 Tf/F82 1 Tf( )Tj/F107 9.9626 Tf -120.995 -11.955 Td [(\134iflatextortf)]TJ/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 77.709 0 Td [(.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 5.579 0 Td [(If)]TJ
+/F108 9.9626 Tf/F84 1 Tf( )Tj/F108 9.9626 Tf -120.995 -11.955 Td [(\134iflatextortf)]TJ/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 77.709 0 Td [(.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 5.579 0 Td [(If)]TJ
 ET
 1 0 0 1 164.413 217.982 cm
 EMC
 /Span <</MCID 433>> BDC
 1 0 0 1 -164.413 -217.982 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 164.413 217.982 Td [(latex2rtf)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 164.413 217.982 Td [(latex2rtf)]TJ
 ET
 1 0 0 1 200.408 217.982 cm
 EMC
 /P <</MCID 434>> BDC
 1 0 0 1 -200.408 -217.982 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 202.898 217.982 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(used,)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 202.898 217.982 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(used,)]TJ
 0 g 0 G
 0 g 0 G
-/F107 9.9626 Tf/F82 1 Tf( )Tj/F107 9.9626 Tf -140.034 -11.956 Td [(\134iflatextortf)]TJ/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 80.199 0 Td [(will)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.992 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.896 0 Td [(TR)40(UE.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.595 0 Td [(This)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(means)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.945 0 Td [(that)]TJ
+/F108 9.9626 Tf/F84 1 Tf( )Tj/F108 9.9626 Tf -140.034 -11.956 Td [(\134iflatextortf)]TJ/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 80.199 0 Td [(will)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.992 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.896 0 Td [(TR)40(UE.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.595 0 Td [(This)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(means)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.945 0 Td [(that)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -188.831 -11.955 Td [(we)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(create)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.271 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(preamble)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.561 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.434 0 Td [(accommodates)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 61.698 0 Td [(both)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(paths:)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -188.831 -11.955 Td [(we)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(create)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.271 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(preamble)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.561 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.434 0 Td [(accommodates)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 61.698 0 Td [(both)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(paths:)]TJ
 0 g 0 G
 0 g 0 G
 1 g 1 G
@@ -6596,7 +6596,7 @@ Q
 0 g 0 G
 0.5 g 0.5 G
 BT
-/F79 4.9813 Tf/F82 1 Tf( )Tj/F79 4.9813 Tf 64.528 166.004 Td [(2)]TJ
+/F80 4.9813 Tf/F84 1 Tf( )Tj/F80 4.9813 Tf 64.528 166.004 Td [(2)]TJ
 0 g 0 G
 ET
 1 0 0 1 72 166.004 cm
@@ -6605,11 +6605,11 @@ EMC
 /P <</MCID 435>> BDC
 1 0 0 1 -72 -155.045 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 73.444 155.045 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 73.444 155.045 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 4.931 0 Td [(n)-111(e)-111(w)-111(i)-111(f)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 4.931 0 Td [(n)-111(e)-111(w)-111(i)-111(f)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 27.348 0 Td [(\134)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 5.912 0 Td [(i)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 3.967 0 Td [(f)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.469 0 Td [(l)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 3.966 0 Td [(a)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.962 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.469 0 Td [(e)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.961 0 Td [(x)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.459 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.469 0 Td [(o)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.961 0 Td [(r)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.962 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.469 0 Td [(f)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 27.348 0 Td [(\134)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 5.912 0 Td [(i)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 3.967 0 Td [(f)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.469 0 Td [(l)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 3.966 0 Td [(a)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.962 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.469 0 Td [(e)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.961 0 Td [(x)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.459 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.469 0 Td [(o)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.961 0 Td [(r)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.962 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.469 0 Td [(f)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -6623,7 +6623,7 @@ EMC
 /P <</MCID 437>> BDC
 1 0 0 1 -72 -133.127 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 73.444 133.127 Td [(\134)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 5.912 0 Td [(i)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 3.967 0 Td [(f)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.468 0 Td [(l)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 3.967 0 Td [(a)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.961 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.469 0 Td [(e)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.962 0 Td [(x)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.459 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.469 0 Td [(o)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.961 0 Td [(r)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.962 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.469 0 Td [(f)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 73.444 133.127 Td [(\134)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 5.912 0 Td [(i)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 3.967 0 Td [(f)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.468 0 Td [(l)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 3.967 0 Td [(a)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.961 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.469 0 Td [(e)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.962 0 Td [(x)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.459 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.469 0 Td [(o)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.961 0 Td [(r)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.962 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.469 0 Td [(f)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -6632,11 +6632,11 @@ EMC
 /P <</MCID 438>> BDC
 1 0 0 1 -72 -122.169 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 94.963 122.169 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 94.963 122.169 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 4.661 0 Td [(d)-81(o)-81(c)-80(u)-81(m)-81(e)-81(n)-81(t)-80(c)-81(l)-81(a)-81(s)-80(s)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 4.661 0 Td [(d)-81(o)-81(c)-80(u)-81(m)-81(e)-81(n)-81(t)-80(c)-81(l)-81(a)-81(s)-80(s)]TJ
 0 g 0 G
- [-184([)-102(1)-103(0)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 86.447 0 Td [(p)-122(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 11.424 0 Td [(])-196({)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 10.268 0 Td [(r)-141(e)-141(p)-141(o)-142(r)-141(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 32.206 0 Td [(})]TJ
+ [-184([)-102(1)-103(0)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 86.447 0 Td [(p)-122(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 11.424 0 Td [(])-196({)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 10.268 0 Td [(r)-141(e)-141(p)-141(o)-142(r)-141(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 32.206 0 Td [(})]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -6645,11 +6645,11 @@ EMC
 /P <</MCID 439>> BDC
 1 0 0 1 -72 -111.21 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 94.963 111.21 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 94.963 111.21 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 5.18 0 Td [(i)-139(n)-138(p)-139(u)-139(t)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 5.18 0 Td [(i)-139(n)-138(p)-139(u)-139(t)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 26.848 0 Td [({)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 5.016 0 Td [(L)-92(a)-93(t)-92(e)-92(x)-115(2)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 33.493 0 Td [(r)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 5.028 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.535 0 Td [(f)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.732 0 Td [(_)-57(m)-36(e)-35(t)-36(a)-57(_)-146(w)-125(i)-124(t)-125(h)-146(_)-83(a)-61(c)-61(c)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 76.565 0 Td [(.)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.98 0 Td [(t)-117(e)-116(x)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 16.288 0 Td [(})]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 26.848 0 Td [({)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 5.016 0 Td [(L)-92(a)-93(t)-92(e)-92(x)-115(2)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 33.493 0 Td [(r)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 5.028 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.535 0 Td [(f)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.732 0 Td [(_)-57(m)-36(e)-35(t)-36(a)-57(_)-146(w)-125(i)-124(t)-125(h)-146(_)-83(a)-61(c)-61(c)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 76.565 0 Td [(.)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.98 0 Td [(t)-117(e)-116(x)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 16.288 0 Td [(})]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -6658,9 +6658,9 @@ EMC
 /P <</MCID 440>> BDC
 1 0 0 1 -72 -100.251 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 73.444 100.251 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 73.444 100.251 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 4.951 0 Td [(e)-113(l)-113(s)-114(e)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 4.951 0 Td [(e)-113(l)-113(s)-114(e)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -6670,11 +6670,11 @@ EMC
 /P <</MCID 441>> BDC
 1 0 0 1 -72 -89.292 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 94.963 89.292 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 94.963 89.292 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 4.661 0 Td [(d)-81(o)-81(c)-80(u)-81(m)-81(e)-81(n)-81(t)-80(c)-81(l)-81(a)-81(s)-80(s)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 4.661 0 Td [(d)-81(o)-81(c)-80(u)-81(m)-81(e)-81(n)-81(t)-80(c)-81(l)-81(a)-81(s)-80(s)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 70.658 0 Td [([)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 5.215 0 Td [(d)-143(r)-142(a)-143(f)-143(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 27.064 0 Td [(,)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 10.582 0 Td [(r)-141(e)-141(p)-141(o)-142(r)-141(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 32.771 0 Td [(])-196({)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 9.319 0 Td [(m)-35(e)-36(t)-35(a)-169(})]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 70.658 0 Td [([)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 5.215 0 Td [(d)-143(r)-142(a)-143(f)-143(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 27.064 0 Td [(,)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 10.582 0 Td [(r)-141(e)-141(p)-141(o)-142(r)-141(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 32.771 0 Td [(])-196({)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 9.319 0 Td [(m)-35(e)-36(t)-35(a)-169(})]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -6683,9 +6683,9 @@ EMC
 /P <</MCID 442>> BDC
 1 0 0 1 -72 -78.333 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 73.444 78.333 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 73.444 78.333 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 6.028 0 Td [(f)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.585 0 Td [(i)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 6.028 0 Td [(f)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.585 0 Td [(i)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -6704,7 +6704,7 @@ EMC
 /H <</MCID 444>> BDC
 1 0 0 1 -310.981 -674.037 cm
 BT
-/F92 9.9626 Tf/F82 1 Tf( )Tj/F92 9.9626 Tf 310.981 674.037 Td [(4.1)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 23.811 0 Td [(Inc)20(luding)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 46.854 0 Td [(code)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 26.022 0 Td [(listings)]TJ
+/F94 9.9626 Tf/F84 1 Tf( )Tj/F94 9.9626 Tf 310.981 674.037 Td [(4.1)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 23.811 0 Td [(Inc)20(luding)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 46.854 0 Td [(code)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 26.022 0 Td [(listings)]TJ
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 g 0 G
@@ -6715,41 +6715,41 @@ EMC
 /P <</MCID 445>> BDC
 1 0 0 1 -310.981 -654.602 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 654.602 Td [(The)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 654.602 Td [(The)]TJ
 ET
 1 0 0 1 328.964 654.602 cm
 EMC
 /Span <</MCID 446>> BDC
 1 0 0 1 -328.964 -654.602 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 328.964 654.602 Td [(listings)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 328.964 654.602 Td [(listings)]TJ
 ET
 1 0 0 1 358.313 654.602 cm
 EMC
 /P <</MCID 447>> BDC
 1 0 0 1 -358.313 -654.602 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 360.804 654.602 Td [(package)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.128 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.135 0 Td [(one)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(se)25(v)15(eral)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.306 0 Td [(packages)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.004 0 Td [(that)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 360.804 654.602 Td [(package)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.128 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.135 0 Td [(one)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(se)25(v)15(eral)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.306 0 Td [(packages)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.004 0 Td [(that)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -191.062 -11.955 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(used)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(typeset)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.714 0 Td [(source)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.493 0 Td [(code,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.791 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(used)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.752 0 Td [(in)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(this)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -191.062 -11.955 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(used)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(typeset)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.714 0 Td [(source)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.493 0 Td [(code,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.791 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(used)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.752 0 Td [(in)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(this)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -199.211 -11.956 Td [(document.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 44.872 0 Td [(Unfortunately)65(,)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -199.211 -11.956 Td [(document.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 44.872 0 Td [(Unfortunately)65(,)]TJ
 ET
 1 0 0 1 416.076 630.691 cm
 EMC
 /Span <</MCID 448>> BDC
 1 0 0 1 -416.076 -630.691 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 416.076 630.691 Td [(listings)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 416.076 630.691 Td [(listings)]TJ
 ET
 1 0 0 1 445.426 630.691 cm
 EMC
 /P <</MCID 449>> BDC
 1 0 0 1 -445.426 -630.691 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 447.916 630.691 Td [(is)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.136 0 Td [(not)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(compatible)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 46.764 0 Td [(with)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 447.916 630.691 Td [(is)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.136 0 Td [(not)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(compatible)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 46.764 0 Td [(with)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -6758,45 +6758,45 @@ EMC
 /Span <</MCID 450>> BDC
 1 0 0 1 -310.981 -618.736 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 310.981 618.736 Td [(latex2rtf)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 310.981 618.736 Td [(latex2rtf)]TJ
 ET
 1 0 0 1 346.976 618.736 cm
 EMC
 /P <</MCID 451>> BDC
 1 0 0 1 -346.976 -618.736 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 346.976 618.736 Td [(,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 4.981 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.877 0 Td [(so)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.347 0 Td [(we)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(need)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(w)10(orkaround)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 50.53 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(will)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.992 0 Td [(be)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 346.976 618.736 Td [(,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 4.981 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.877 0 Td [(so)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.347 0 Td [(we)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(need)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(w)10(orkaround)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 50.53 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(will)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.992 0 Td [(be)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -197.478 -11.955 Td [(a)20(v)25(ailable)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.007 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(both)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -197.478 -11.955 Td [(a)20(v)25(ailable)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.007 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(both)]TJ
 ET
 1 0 0 1 379.434 606.781 cm
 EMC
 /Span <</MCID 452>> BDC
 1 0 0 1 -379.434 -606.781 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 379.434 606.781 Td [(latex2rtf)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 379.434 606.781 Td [(latex2rtf)]TJ
 ET
 1 0 0 1 415.428 606.781 cm
 EMC
 /P <</MCID 453>> BDC
 1 0 0 1 -415.428 -606.781 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 417.919 606.781 Td [(and)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 417.919 606.781 Td [(and)]TJ
 ET
 1 0 0 1 434.796 606.781 cm
 EMC
 /Span <</MCID 454>> BDC
 1 0 0 1 -434.796 -606.781 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 434.796 606.781 Td [(pd\003atex)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 434.796 606.781 Td [(pd\003atex)]TJ
 ET
 1 0 0 1 467.453 606.781 cm
 EMC
 /P <</MCID 455>> BDC
 1 0 0 1 -467.453 -606.781 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 467.453 606.781 Td [(.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 467.453 606.781 Td [(.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -6805,44 +6805,44 @@ EMC
 /P <</MCID 456>> BDC
 1 0 0 1 -310.981 -588.585 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 310.981 588.585 Td [(Using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.291 0 Td [(an)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.896 0 Td [(e)15(xample)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.094 0 Td [(from)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(W)80(erner)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 31.561 0 Td [(posted)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.503 0 Td [(on)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 310.981 588.585 Td [(Using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.291 0 Td [(an)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.896 0 Td [(e)15(xample)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.094 0 Td [(from)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(W)80(erner)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 31.561 0 Td [(posted)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.503 0 Td [(on)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -156.203 -11.955 Td [(te)15(x.stack)10(e)15(xchange.com,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 96.986 0 Td [(we)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(def)10(ault)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.057 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(the)]TJ/F107 9.9626 Tf/F82 1 Tf( )Tj/F107 9.9626 Tf 14.665 0 Td [(verbatim)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -156.203 -11.955 Td [(te)15(x.stack)10(e)15(xchange.com,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 96.986 0 Td [(we)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(def)10(ault)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.057 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(the)]TJ/F108 9.9626 Tf/F84 1 Tf( )Tj/F108 9.9626 Tf 14.665 0 Td [(verbatim)]TJ
 0 g 0 G
 0 g 0 G
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf -166.056 -11.956 Td [(en)40(vironment,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 54.944 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(only)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.205 0 Td [(use)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf -166.056 -11.956 Td [(en)40(vironment,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 54.944 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(only)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.205 0 Td [(use)]TJ
 ET
 1 0 0 1 418.776 564.674 cm
 EMC
 /Span <</MCID 457>> BDC
 1 0 0 1 -418.776 -564.674 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 418.776 564.674 Td [(listings)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 418.776 564.674 Td [(listings)]TJ
 ET
 1 0 0 1 448.126 564.674 cm
 EMC
 /P <</MCID 458>> BDC
 1 0 0 1 -448.126 -564.674 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 450.616 564.674 Td [(if)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 8.578 0 Td [(we)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(compiling)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 450.616 564.674 Td [(if)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 8.578 0 Td [(we)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(compiling)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -176.975 -11.955 Td [(with)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -176.975 -11.955 Td [(with)]TJ
 ET
 1 0 0 1 331.185 552.719 cm
 EMC
 /Span <</MCID 459>> BDC
 1 0 0 1 -331.185 -552.719 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 331.185 552.719 Td [(pd\003atex)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 331.185 552.719 Td [(pd\003atex)]TJ
 ET
 1 0 0 1 363.843 552.719 cm
 EMC
 /P <</MCID 460>> BDC
 1 0 0 1 -363.843 -552.719 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 363.843 552.719 Td [(:)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 363.843 552.719 Td [(:)]TJ
 0 g 0 G
 0 g 0 G
 1 g 1 G
@@ -6858,7 +6858,7 @@ Q
 0 g 0 G
 0.5 g 0.5 G
 BT
-/F79 4.9813 Tf/F82 1 Tf( )Tj/F79 4.9813 Tf 303.509 524.56 Td [(2)]TJ
+/F80 4.9813 Tf/F84 1 Tf( )Tj/F80 4.9813 Tf 303.509 524.56 Td [(2)]TJ
 0 g 0 G
 ET
 1 0 0 1 310.981 524.56 cm
@@ -6867,9 +6867,9 @@ EMC
 /P <</MCID 461>> BDC
 1 0 0 1 -310.981 -513.601 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 312.425 513.601 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 312.425 513.601 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 5.107 0 Td [(m)-131(a)-130(k)-131(e)-131(a)-130(t)-131(l)-130(e)-131(t)-131(t)-130(e)-131(r)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 5.107 0 Td [(m)-131(a)-130(k)-131(e)-131(a)-130(t)-131(l)-130(e)-131(t)-131(t)-130(e)-131(r)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -6879,7 +6879,7 @@ EMC
 /P <</MCID 462>> BDC
 1 0 0 1 -310.981 -502.643 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 312.425 502.643 Td [(\134)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.828 0 Td [(@)-99(i)-100(f)-99(u)-100(n)-99(d)-100(e)-99(f)-100(i)-99(n)-100(e)-99(d)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 64.859 0 Td [({)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.18 0 Td [(l)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 3.983 0 Td [(s)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.475 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.485 0 Td [(l)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 3.983 0 Td [(i)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 3.982 0 Td [(s)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.476 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.485 0 Td [(i)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 3.982 0 Td [(n)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.978 0 Td [(g)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 8.886 0 Td [(})]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.902 0 Td [({)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.903 0 Td [(})]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.903 0 Td [({)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 312.425 502.643 Td [(\134)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.828 0 Td [(@)-99(i)-100(f)-99(u)-100(n)-99(d)-100(e)-99(f)-100(i)-99(n)-100(e)-99(d)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 64.859 0 Td [({)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.18 0 Td [(l)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 3.983 0 Td [(s)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.475 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.485 0 Td [(l)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 3.983 0 Td [(i)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 3.982 0 Td [(s)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.476 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.485 0 Td [(i)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 3.982 0 Td [(n)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.978 0 Td [(g)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 8.886 0 Td [(})]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.902 0 Td [({)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.903 0 Td [(})]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.903 0 Td [({)]TJ
 0.5 g 0.5 G
  [-68(%)]TJ
 0 g 0 G
@@ -6891,17 +6891,17 @@ EMC
 /P <</MCID 463>> BDC
 1 0 0 1 -310.981 -491.684 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 323.185 491.684 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 323.185 491.684 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 5.604 0 Td [(l)-186(e)-186(t)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 5.604 0 Td [(l)-186(e)-186(t)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 15.915 0 Td [(\134)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 15.915 0 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 4.899 0 Td [(v)-107(e)-108(r)-107(b)-107(a)-108(t)-107(i)-107(m)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 4.899 0 Td [(v)-107(e)-108(r)-107(b)-107(a)-108(t)-107(i)-107(m)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 43.52 0 Td [(\134)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 43.52 0 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 5.181 0 Td [(r)-139(e)-139(l)-139(a)-138(x)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 5.181 0 Td [(r)-139(e)-139(l)-139(a)-138(x)]TJ
 0 g 0 G
 0.5 g 0.5 G
  [5(%)]TJ
@@ -6914,7 +6914,7 @@ EMC
 /P <</MCID 464>> BDC
 1 0 0 1 -310.981 -480.725 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 323.185 480.725 Td [(\134)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.865 0 Td [(l)-104(s)-103(t)-104(n)-103(e)-104(w)-103(e)-104(n)-103(v)-104(i)-104(r)-103(o)-104(n)-103(m)-104(e)-103(n)-104(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 91.722 0 Td [({)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 5.149 0 Td [(v)-107(e)-108(r)-107(b)-107(a)-108(t)-107(i)-107(m)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 43.667 0 Td [(})-177({)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 323.185 480.725 Td [(\134)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.865 0 Td [(l)-104(s)-103(t)-104(n)-103(e)-104(w)-103(e)-104(n)-103(v)-104(i)-104(r)-103(o)-104(n)-103(m)-104(e)-103(n)-104(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 91.722 0 Td [({)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 5.149 0 Td [(v)-107(e)-108(r)-107(b)-107(a)-108(t)-107(i)-107(m)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 43.667 0 Td [(})-177({)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -6923,7 +6923,7 @@ EMC
 /P <</MCID 465>> BDC
 1 0 0 1 -310.981 -469.766 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 344.704 469.766 Td [(\134)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 5.558 0 Td [(l)-181(s)-181(t)-181(s)-180(e)-181(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 31.85 0 Td [({)-209(l)-76(a)-77(n)-76(g)-76(u)-76(a)-77(g)-76(e)-189(=)-112([)-122(L)-9(a)-9(T)-9(e)-9(X)-170(])-154(T)6(e)7(X)-147(,)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 344.704 469.766 Td [(\134)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 5.558 0 Td [(l)-181(s)-181(t)-181(s)-180(e)-181(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 31.85 0 Td [({)-209(l)-76(a)-77(n)-76(g)-76(u)-76(a)-77(g)-76(e)-189(=)-112([)-122(L)-9(a)-9(T)-9(e)-9(X)-170(])-154(T)6(e)7(X)-147(,)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -6932,34 +6932,34 @@ EMC
 /P <</MCID 466>> BDC
 1 0 0 1 -310.981 -458.807 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 345.426 458.807 Td [(.)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.658 0 Td [(.)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.658 0 Td [(.)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 345.426 458.807 Td [(.)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.658 0 Td [(.)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.658 0 Td [(.)]TJ
 0.5 g 0.5 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 8.743 0 Td [(%)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 8.743 0 Td [(%)]TJ
 0 g 0 G
 0.5 g 0.5 G
 0 g 0 G
 0.5 g 0.5 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 12.77 0 Td [(h)-80(e)-80(r)-79(e)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 12.77 0 Td [(h)-80(e)-80(r)-79(e)]TJ
 0 g 0 G
 0.5 g 0.5 G
 0 g 0 G
 0.5 g 0.5 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 25.951 0 Td [(w)26(e)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 25.951 0 Td [(w)26(e)]TJ
 0 g 0 G
 0.5 g 0.5 G
 0 g 0 G
 0.5 g 0.5 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 16.794 0 Td [(c)-47(a)-47(n)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 16.794 0 Td [(c)-47(a)-47(n)]TJ
 0 g 0 G
 0.5 g 0.5 G
 0 g 0 G
 0.5 g 0.5 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 21.905 0 Td [(c)-90(u)-90(s)-90(t)-90(o)-89(m)-90(i)-90(z)-90(e)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 21.905 0 Td [(c)-90(u)-90(s)-90(t)-90(o)-89(m)-90(i)-90(z)-90(e)]TJ
 0 g 0 G
 0.5 g 0.5 G
 0 g 0 G
 0.5 g 0.5 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 53.911 0 Td [(t)-103(h)-102(e)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 53.911 0 Td [(t)-103(h)-102(e)]TJ
 0 g 0 G
 0.5 g 0.5 G
 0 g 0 G
@@ -6978,7 +6978,7 @@ Q
 0 g 0 G
 0.5 g 0.5 G
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 365.029 447.848 Td [(l)-205(i)-206(s)-205(t)-206(i)-205(n)-206(g)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 365.029 447.848 Td [(l)-205(i)-206(s)-205(t)-206(i)-205(n)-206(g)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -6988,7 +6988,7 @@ EMC
 /P <</MCID 467>> BDC
 1 0 0 1 -310.981 -436.889 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 323.649 436.889 Td [(})]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.903 0 Td [(})]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.903 0 Td [({)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.903 0 Td [(})]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 323.649 436.889 Td [(})]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.903 0 Td [(})]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.903 0 Td [({)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.903 0 Td [(})]TJ
 0.5 g 0.5 G
  [-68(%)]TJ
 0 g 0 G
@@ -7000,7 +7000,7 @@ EMC
 /P <</MCID 468>> BDC
 1 0 0 1 -310.981 -425.93 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 312.174 425.93 Td [(})]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 312.174 425.93 Td [(})]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -7009,9 +7009,9 @@ EMC
 /P <</MCID 469>> BDC
 1 0 0 1 -310.981 -414.971 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 312.425 414.971 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 312.425 414.971 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 4.715 0 Td [(m)-87(a)-87(k)-87(e)-86(a)-87(t)-87(o)-87(t)-87(h)-87(e)-86(r)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 4.715 0 Td [(m)-87(a)-87(k)-87(e)-86(a)-87(t)-87(o)-87(t)-87(h)-87(e)-86(r)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -7025,7 +7025,7 @@ EMC
 /H <</MCID 470>> BDC
 1 0 0 1 -310.981 -375.371 cm
 BT
-/F92 9.9626 Tf/F82 1 Tf( )Tj/F92 9.9626 Tf 310.981 375.371 Td [(4.2)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 23.811 0 Td [(The)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 20.483 0 Td [(\002nal)]TJ/F82 1 Tf( )Tj/F92 9.9626 Tf 23.252 0 Td [(preamb)10(le)]TJ
+/F94 9.9626 Tf/F84 1 Tf( )Tj/F94 9.9626 Tf 310.981 375.371 Td [(4.2)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 23.811 0 Td [(The)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 20.483 0 Td [(\002nal)]TJ/F84 1 Tf( )Tj/F94 9.9626 Tf 23.252 0 Td [(preamb)10(le)]TJ
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 g 0 G
@@ -7045,18 +7045,18 @@ Q
 0.5 g 0.5 G
 1 0 0 1 -310.981 -372.069 cm
 BT
-/F79 4.9813 Tf/F82 1 Tf( )Tj/F79 4.9813 Tf 303.509 345.973 Td [(2)]TJ
+/F80 4.9813 Tf/F84 1 Tf( )Tj/F80 4.9813 Tf 303.509 345.973 Td [(2)]TJ
 0 g 0 G
 ET
 1 0 0 1 310.981 335.014 cm
 /P <</MCID 471>> BDC
 1 0 0 1 -310.981 -335.014 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 312.425 335.014 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 312.425 335.014 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 4.932 0 Td [(n)-111(e)-111(w)-111(i)-111(f)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 4.932 0 Td [(n)-111(e)-111(w)-111(i)-111(f)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 27.347 0 Td [(\134)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 5.913 0 Td [(i)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 3.966 0 Td [(f)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.469 0 Td [(l)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 3.967 0 Td [(a)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.961 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.469 0 Td [(e)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.961 0 Td [(x)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.46 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.468 0 Td [(o)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.962 0 Td [(r)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.962 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.468 0 Td [(f)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 27.347 0 Td [(\134)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 5.913 0 Td [(i)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 3.966 0 Td [(f)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.469 0 Td [(l)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 3.967 0 Td [(a)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.961 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.469 0 Td [(e)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.961 0 Td [(x)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.46 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.468 0 Td [(o)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.962 0 Td [(r)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.962 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.468 0 Td [(f)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -7070,7 +7070,7 @@ EMC
 /P <</MCID 473>> BDC
 1 0 0 1 -310.981 -313.096 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 312.425 313.096 Td [(\134)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 5.912 0 Td [(i)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 3.967 0 Td [(f)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.469 0 Td [(l)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 3.966 0 Td [(a)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.962 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.469 0 Td [(e)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.961 0 Td [(x)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.459 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.469 0 Td [(o)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.961 0 Td [(r)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.962 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.469 0 Td [(f)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 312.425 313.096 Td [(\134)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 5.912 0 Td [(i)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 3.967 0 Td [(f)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.469 0 Td [(l)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 3.966 0 Td [(a)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.962 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.469 0 Td [(e)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.961 0 Td [(x)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.459 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.469 0 Td [(o)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.961 0 Td [(r)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.962 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.469 0 Td [(f)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -7079,11 +7079,11 @@ EMC
 /P <</MCID 474>> BDC
 1 0 0 1 -310.981 -302.137 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 333.945 302.137 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 333.945 302.137 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 4.66 0 Td [(d)-81(o)-81(c)-80(u)-81(m)-81(e)-81(n)-81(t)-80(c)-81(l)-81(a)-81(s)-81(s)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 4.66 0 Td [(d)-81(o)-81(c)-80(u)-81(m)-81(e)-81(n)-81(t)-80(c)-81(l)-81(a)-81(s)-81(s)]TJ
 0 g 0 G
- [-183([)-102(1)-103(0)-194(p)-91(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 97.557 0 Td [(,)]TJ
+ [-183([)-102(1)-103(0)-194(p)-91(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 97.557 0 Td [(,)]TJ
 0 g 0 G
 0 g 0 G
 1 g 1 G
@@ -7098,7 +7098,7 @@ Q
 1 g 1 G
 0 g 0 G
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 312.341 291.178 Td [(l)-152(e)-151(t)-152(t)-152(e)-151(r)-152(p)-152(a)-151(p)-152(e)-152(r)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 59.576 0 Td [(])-196({)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 10.268 0 Td [(r)-141(e)-141(p)-141(o)-142(r)-141(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 32.207 0 Td [(})]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 312.341 291.178 Td [(l)-152(e)-151(t)-152(t)-152(e)-151(r)-152(p)-152(a)-151(p)-152(e)-152(r)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 59.576 0 Td [(])-196({)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 10.268 0 Td [(r)-141(e)-141(p)-141(o)-142(r)-141(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 32.207 0 Td [(})]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -7107,11 +7107,11 @@ EMC
 /P <</MCID 475>> BDC
 1 0 0 1 -310.981 -280.219 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 333.945 280.219 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 333.945 280.219 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 5.179 0 Td [(i)-139(n)-138(p)-139(u)-139(t)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 5.179 0 Td [(i)-139(n)-138(p)-139(u)-139(t)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 26.849 0 Td [({)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 5.015 0 Td [(L)-92(a)-93(t)-92(e)-92(x)-115(2)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 33.493 0 Td [(r)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 5.028 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.535 0 Td [(f)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.732 0 Td [(_)-57(m)-36(e)-35(t)-36(a)-57(_)-146(w)-125(i)-124(t)-125(h)-146(_)-83(a)-61(c)-61(c)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 76.565 0 Td [(.)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.981 0 Td [(t)-116(e)-117(x)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 16.287 0 Td [(})]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 26.849 0 Td [({)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 5.015 0 Td [(L)-92(a)-93(t)-92(e)-92(x)-115(2)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 33.493 0 Td [(r)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 5.028 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.535 0 Td [(f)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.732 0 Td [(_)-57(m)-36(e)-35(t)-36(a)-57(_)-146(w)-125(i)-124(t)-125(h)-146(_)-83(a)-61(c)-61(c)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 76.565 0 Td [(.)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.981 0 Td [(t)-116(e)-117(x)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 16.287 0 Td [(})]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -7120,9 +7120,9 @@ EMC
 /P <</MCID 476>> BDC
 1 0 0 1 -310.981 -269.26 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 312.425 269.26 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 312.425 269.26 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 4.951 0 Td [(e)-113(l)-113(s)-114(e)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 4.951 0 Td [(e)-113(l)-113(s)-114(e)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -7132,11 +7132,11 @@ EMC
 /P <</MCID 477>> BDC
 1 0 0 1 -310.981 -258.301 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 333.945 258.301 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 333.945 258.301 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 4.66 0 Td [(d)-81(o)-81(c)-80(u)-81(m)-81(e)-81(n)-81(t)-80(c)-81(l)-81(a)-81(s)-81(s)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 4.66 0 Td [(d)-81(o)-81(c)-80(u)-81(m)-81(e)-81(n)-81(t)-80(c)-81(l)-81(a)-81(s)-81(s)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 70.658 0 Td [([)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 5.216 0 Td [(d)-143(r)-142(a)-143(f)-143(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 27.063 0 Td [(,)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 10.582 0 Td [(r)-141(e)-141(p)-141(o)-142(r)-141(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 32.771 0 Td [(])-196({)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 9.32 0 Td [(m)-35(e)-36(t)-35(a)-169(})]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 70.658 0 Td [([)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 5.216 0 Td [(d)-143(r)-142(a)-143(f)-143(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 27.063 0 Td [(,)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 10.582 0 Td [(r)-141(e)-141(p)-141(o)-142(r)-141(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 32.771 0 Td [(])-196({)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 9.32 0 Td [(m)-35(e)-36(t)-35(a)-169(})]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -7145,9 +7145,9 @@ EMC
 /P <</MCID 478>> BDC
 1 0 0 1 -310.981 -247.342 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 312.425 247.342 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 312.425 247.342 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 6.028 0 Td [(f)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.585 0 Td [(i)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 6.028 0 Td [(f)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.585 0 Td [(i)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -7162,9 +7162,9 @@ EMC
 /P <</MCID 480>> BDC
 1 0 0 1 -310.981 -225.425 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 312.425 225.425 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 312.425 225.425 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 5.107 0 Td [(m)-131(a)-130(k)-131(e)-131(a)-130(t)-131(l)-130(e)-131(t)-131(t)-130(e)-131(r)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 5.107 0 Td [(m)-131(a)-130(k)-131(e)-131(a)-130(t)-131(l)-130(e)-131(t)-131(t)-130(e)-131(r)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -7174,7 +7174,7 @@ EMC
 /P <</MCID 481>> BDC
 1 0 0 1 -310.981 -214.466 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 312.425 214.466 Td [(\134)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.828 0 Td [(@)-99(i)-100(f)-99(u)-100(n)-99(d)-100(e)-99(f)-100(i)-99(n)-100(e)-99(d)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 64.859 0 Td [({)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.18 0 Td [(l)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 3.983 0 Td [(s)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.475 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.485 0 Td [(l)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 3.983 0 Td [(i)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 3.982 0 Td [(s)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.476 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.485 0 Td [(i)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 3.982 0 Td [(n)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 6.978 0 Td [(g)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 8.886 0 Td [(})]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.902 0 Td [({)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.903 0 Td [(})]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.903 0 Td [({)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 312.425 214.466 Td [(\134)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.828 0 Td [(@)-99(i)-100(f)-99(u)-100(n)-99(d)-100(e)-99(f)-100(i)-99(n)-100(e)-99(d)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 64.859 0 Td [({)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.18 0 Td [(l)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 3.983 0 Td [(s)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.475 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.485 0 Td [(l)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 3.983 0 Td [(i)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 3.982 0 Td [(s)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.476 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.485 0 Td [(i)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 3.982 0 Td [(n)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 6.978 0 Td [(g)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 8.886 0 Td [(})]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.902 0 Td [({)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.903 0 Td [(})]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.903 0 Td [({)]TJ
 0.5 g 0.5 G
  [-68(%)]TJ
 0 g 0 G
@@ -7186,17 +7186,17 @@ EMC
 /P <</MCID 482>> BDC
 1 0 0 1 -310.981 -203.507 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 323.185 203.507 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 323.185 203.507 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 5.604 0 Td [(l)-186(e)-186(t)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 5.604 0 Td [(l)-186(e)-186(t)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 15.915 0 Td [(\134)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 15.915 0 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 4.899 0 Td [(v)-107(e)-108(r)-107(b)-107(a)-108(t)-107(i)-107(m)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 4.899 0 Td [(v)-107(e)-108(r)-107(b)-107(a)-108(t)-107(i)-107(m)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 43.52 0 Td [(\134)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 43.52 0 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 5.181 0 Td [(r)-139(e)-139(l)-139(a)-138(x)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 5.181 0 Td [(r)-139(e)-139(l)-139(a)-138(x)]TJ
 0 g 0 G
 0.5 g 0.5 G
  [5(%)]TJ
@@ -7209,7 +7209,7 @@ EMC
 /P <</MCID 483>> BDC
 1 0 0 1 -310.981 -192.548 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 323.185 192.548 Td [(\134)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.865 0 Td [(l)-104(s)-103(t)-104(n)-103(e)-104(w)-103(e)-104(n)-103(v)-104(i)-104(r)-103(o)-104(n)-103(m)-104(e)-103(n)-104(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 91.722 0 Td [({)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 5.149 0 Td [(v)-107(e)-108(r)-107(b)-107(a)-108(t)-107(i)-107(m)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 43.667 0 Td [(})-177({)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 323.185 192.548 Td [(\134)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.865 0 Td [(l)-104(s)-103(t)-104(n)-103(e)-104(w)-103(e)-104(n)-103(v)-104(i)-104(r)-103(o)-104(n)-103(m)-104(e)-103(n)-104(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 91.722 0 Td [({)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 5.149 0 Td [(v)-107(e)-108(r)-107(b)-107(a)-108(t)-107(i)-107(m)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 43.667 0 Td [(})-177({)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -7218,7 +7218,7 @@ EMC
 /P <</MCID 484>> BDC
 1 0 0 1 -310.981 -181.589 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 344.704 181.589 Td [(\134)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 5.558 0 Td [(l)-181(s)-181(t)-181(s)-180(e)-181(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 31.85 0 Td [({)-209(l)-76(a)-77(n)-76(g)-76(u)-76(a)-77(g)-76(e)-189(=)-112([)-122(L)-9(a)-9(T)-9(e)-9(X)-170(])-154(T)6(e)7(X)-147(,)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 344.704 181.589 Td [(\134)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 5.558 0 Td [(l)-181(s)-181(t)-181(s)-180(e)-181(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 31.85 0 Td [({)-209(l)-76(a)-77(n)-76(g)-76(u)-76(a)-77(g)-76(e)-189(=)-112([)-122(L)-9(a)-9(T)-9(e)-9(X)-170(])-154(T)6(e)7(X)-147(,)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -7227,34 +7227,34 @@ EMC
 /P <</MCID 485>> BDC
 1 0 0 1 -310.981 -170.63 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 345.426 170.63 Td [(.)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.658 0 Td [(.)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.658 0 Td [(.)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 345.426 170.63 Td [(.)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.658 0 Td [(.)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.658 0 Td [(.)]TJ
 0.5 g 0.5 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 8.743 0 Td [(%)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 8.743 0 Td [(%)]TJ
 0 g 0 G
 0.5 g 0.5 G
 0 g 0 G
 0.5 g 0.5 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 12.77 0 Td [(h)-80(e)-80(r)-79(e)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 12.77 0 Td [(h)-80(e)-80(r)-79(e)]TJ
 0 g 0 G
 0.5 g 0.5 G
 0 g 0 G
 0.5 g 0.5 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 25.951 0 Td [(w)26(e)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 25.951 0 Td [(w)26(e)]TJ
 0 g 0 G
 0.5 g 0.5 G
 0 g 0 G
 0.5 g 0.5 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 16.794 0 Td [(c)-47(a)-47(n)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 16.794 0 Td [(c)-47(a)-47(n)]TJ
 0 g 0 G
 0.5 g 0.5 G
 0 g 0 G
 0.5 g 0.5 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 21.905 0 Td [(c)-90(u)-90(s)-90(t)-90(o)-89(m)-90(i)-90(z)-90(e)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 21.905 0 Td [(c)-90(u)-90(s)-90(t)-90(o)-89(m)-90(i)-90(z)-90(e)]TJ
 0 g 0 G
 0.5 g 0.5 G
 0 g 0 G
 0.5 g 0.5 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 53.911 0 Td [(t)-103(h)-102(e)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 53.911 0 Td [(t)-103(h)-102(e)]TJ
 0 g 0 G
 0.5 g 0.5 G
 0 g 0 G
@@ -7273,7 +7273,7 @@ Q
 0 g 0 G
 0.5 g 0.5 G
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 365.029 159.671 Td [(l)-205(i)-206(s)-205(t)-206(i)-205(n)-206(g)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 365.029 159.671 Td [(l)-205(i)-206(s)-205(t)-206(i)-205(n)-206(g)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -7283,7 +7283,7 @@ EMC
 /P <</MCID 486>> BDC
 1 0 0 1 -310.981 -148.712 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 323.649 148.712 Td [(})]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.903 0 Td [(})]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.903 0 Td [({)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.903 0 Td [(})]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 323.649 148.712 Td [(})]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.903 0 Td [(})]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.903 0 Td [({)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.903 0 Td [(})]TJ
 0.5 g 0.5 G
  [-68(%)]TJ
 0 g 0 G
@@ -7295,7 +7295,7 @@ EMC
 /P <</MCID 487>> BDC
 1 0 0 1 -310.981 -137.753 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 312.174 137.753 Td [(})]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 312.174 137.753 Td [(})]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -7304,9 +7304,9 @@ EMC
 /P <</MCID 488>> BDC
 1 0 0 1 -310.981 -126.795 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 312.425 126.795 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 312.425 126.795 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 4.715 0 Td [(m)-87(a)-87(k)-87(e)-86(a)-87(t)-87(o)-87(t)-87(h)-87(e)-86(r)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 4.715 0 Td [(m)-87(a)-87(k)-87(e)-86(a)-87(t)-87(o)-87(t)-87(h)-87(e)-86(r)]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -7321,11 +7321,11 @@ EMC
 /P <</MCID 490>> BDC
 1 0 0 1 -310.981 -104.877 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 312.425 104.877 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 312.425 104.877 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 4.916 0 Td [(a)-109(u)-110(t)-109(h)-109(o)-109(r)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 4.916 0 Td [(a)-109(u)-110(t)-109(h)-109(o)-109(r)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 32.492 0 Td [({)-157(A)-24(n)-25(d)-24(y)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 32.618 0 Td [(C)-171(l)-171(i)-170(f)-171(t)-171(o)-171(n)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 37.321 0 Td [(})]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 32.492 0 Td [({)-157(A)-24(n)-25(d)-24(y)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 32.618 0 Td [(C)-171(l)-171(i)-170(f)-171(t)-171(o)-171(n)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 37.321 0 Td [(})]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -7334,11 +7334,11 @@ EMC
 /P <</MCID 491>> BDC
 1 0 0 1 -310.981 -93.918 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 312.425 93.918 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 312.425 93.918 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 6.094 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.651 0 Td [(i)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.148 0 Td [(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.651 0 Td [(l)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 4.148 0 Td [(e)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 6.094 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.651 0 Td [(i)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.148 0 Td [(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.651 0 Td [(l)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 4.148 0 Td [(e)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 8.336 0 Td [({)-125(S)7(o)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 20.749 0 Td [(y)-47(o)-47(u)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 21.614 0 Td [(w)-58(a)-57(n)-58(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 27.477 0 Td [(t)-122(o)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 16.078 0 Td [(r)-115(e)-115(p)-115(l)-116(a)-115(c)-115(e)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 42.823 0 Td [(y)-91(o)-91(u)-91(r)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 8.336 0 Td [({)-125(S)7(o)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 20.749 0 Td [(y)-47(o)-47(u)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 21.614 0 Td [(w)-58(a)-57(n)-58(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 27.477 0 Td [(t)-122(o)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 16.078 0 Td [(r)-115(e)-115(p)-115(l)-116(a)-115(c)-115(e)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 42.823 0 Td [(y)-91(o)-91(u)-91(r)]TJ
 0 g 0 G
 0 g 0 G
 1 g 1 G
@@ -7353,7 +7353,7 @@ Q
 1 g 1 G
 0 g 0 G
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 310.146 82.959 Td [(W)93(Y)93(S)93(I)93(W)94(Y)93(G)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 44.292 0 Td [(w)-47(o)-46(r)-47(d)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 27.387 0 Td [(p)-101(r)-101(o)-101(c)-101(e)-101(s)-101(s)-101(o)-101(r)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 53.813 0 Td [(b)-102(u)-103(t)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 20.896 0 Td [(5)-33(0)-33(8)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 21.992 0 Td [(c)-86(o)-86(m)-85(p)-86(l)-86(i)-85(a)-86(n)-86(c)-86(e)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 310.146 82.959 Td [(W)93(Y)93(S)93(I)93(W)94(Y)93(G)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 44.292 0 Td [(w)-47(o)-46(r)-47(d)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 27.387 0 Td [(p)-101(r)-101(o)-101(c)-101(e)-101(s)-101(s)-101(o)-101(r)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 53.813 0 Td [(b)-102(u)-103(t)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 20.896 0 Td [(5)-33(0)-33(8)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 21.992 0 Td [(c)-86(o)-86(m)-85(p)-86(l)-86(i)-85(a)-86(n)-86(c)-86(e)]TJ
 0 g 0 G
 0 g 0 G
 1 g 1 G
@@ -7368,7 +7368,7 @@ Q
 1 g 1 G
 0 g 0 G
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 311.403 72 Td [(h)-47(a)-47(s)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 21.519 0 Td [(y)-47(o)-47(u)]TJ/F82 1 Tf( )Tj/F113 8.9664 Tf 21.508 0 Td [(s)-46(t)-45(u)-46(m)-45(p)-46(e)-46(d)-178(})]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 311.403 72 Td [(h)-47(a)-47(s)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 21.519 0 Td [(y)-47(o)-47(u)]TJ/F84 1 Tf( )Tj/F114 8.9664 Tf 21.508 0 Td [(s)-46(t)-45(u)-46(m)-45(p)-46(e)-46(d)-178(})]TJ
 0 g 0 G
 ET
 1 0 0 1 310.981 72 cm
@@ -7379,7 +7379,7 @@ EMC
 /Artifact <</Type /Pagination>> BDC
 1 0 0 1 -72 -42.112 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 303.509 42.112 Td [(6)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 303.509 42.112 Td [(6)]TJ
 ET
 1 0 0 1 540 42.112 cm
 EMC
@@ -7387,17 +7387,17 @@ EMC
 
 endstream
 endobj
-456 0 obj
+458 0 obj
 <<
 /Type /Page
-/Contents 508 0 R
-/Resources 507 0 R
+/Contents 510 0 R
+/Resources 509 0 R
 /MediaBox [0 0 612 792]
-/Parent 152 0 R
-/Annots [ 468 0 R 510 0 R 511 0 R ]
+/Parent 154 0 R
+/Annots [ 470 0 R 512 0 R 513 0 R ]
 >>
 endobj
-468 0 obj
+470 0 obj
 <<
 /Type /Annot
 /Border[0 0 0]/H/I/C[0 1 1]
@@ -7405,7 +7405,7 @@ endobj
 /Subtype/Link/F 4/A<</Type/Action/S/URI/URI(http://latex2rtf.sourceforge.net/latex2rtf.pdf)>>
 >>
 endobj
-510 0 obj
+512 0 obj
 <<
 /Type /Annot
 /Border[0 0 0]/H/I/C[0 1 1]
@@ -7413,7 +7413,7 @@ endobj
 /Subtype/Link/F 4/A<</Type/Action/S/URI/URI(http://latex2rtf.sourceforge.net/latex2rtf.pdf)>>
 >>
 endobj
-511 0 obj
+513 0 obj
 <<
 /Type /Annot
 /Border[0 0 0]/H/I/C[0 1 1]
@@ -7421,125 +7421,135 @@ endobj
 /Subtype/Link/F 4/A<</Type/Action/S/URI/URI(http://latex2rtf.sourceforge.net/latex2rtf.pdf)>>
 >>
 endobj
-509 0 obj
+511 0 obj
 <<
-/D [456 0 R /XYZ 71 718.907 null]
+/D [458 0 R /XYZ 71 718.907 null]
 >>
 endobj
 43 0 obj
 <<
-/D [456 0 R /XYZ 72 365.565 null]
->>
-endobj
-512 0 obj
-<<
-/D [456 0 R /XYZ 72 314.21 null]
->>
-endobj
-513 0 obj
-<<
-/D [456 0 R /XYZ 72 293.964 null]
+/D [458 0 R /XYZ 72 365.565 null]
 >>
 endobj
 514 0 obj
 <<
-/D [456 0 R /XYZ 72 185.765 null]
+/D [458 0 R /XYZ 72 314.21 null]
 >>
 endobj
 515 0 obj
 <<
-/D [456 0 R /XYZ 72 173.675 null]
+/D [458 0 R /XYZ 72 293.964 null]
 >>
 endobj
 516 0 obj
 <<
-/D [456 0 R /XYZ 310.981 544.446 null]
+/D [458 0 R /XYZ 72 185.765 null]
 >>
 endobj
 517 0 obj
 <<
-/D [456 0 R /XYZ 310.981 532.232 null]
+/D [458 0 R /XYZ 72 173.675 null]
+>>
+endobj
+47 0 obj
+<<
+/D [458 0 R /XYZ 310.981 684 null]
 >>
 endobj
 518 0 obj
 <<
-/D [456 0 R /XYZ 310.981 365.828 null]
+/D [458 0 R /XYZ 310.981 544.446 null]
 >>
 endobj
 519 0 obj
 <<
-/D [456 0 R /XYZ 310.981 353.644 null]
+/D [458 0 R /XYZ 310.981 532.232 null]
 >>
 endobj
-507 0 obj
+51 0 obj
+<<
+/D [458 0 R /XYZ 310.981 393.383 null]
+>>
+endobj
+520 0 obj
+<<
+/D [458 0 R /XYZ 310.981 365.828 null]
+>>
+endobj
+521 0 obj
+<<
+/D [458 0 R /XYZ 310.981 353.644 null]
+>>
+endobj
+509 0 obj
 <<
  /ColorSpace 3 0 R /Pattern 2 0 R /ExtGState 1 0 R 
-/Font << /F79 141 0 R /F82 145 0 R /F91 235 0 R /F86 147 0 R /F85 146 0 R /F101 398 0 R /F81 144 0 R /F107 402 0 R /F113 451 0 R /F92 243 0 R >>
+/Font << /F80 143 0 R /F84 147 0 R /F93 237 0 R /F88 149 0 R /F87 148 0 R /F102 400 0 R /F83 146 0 R /F108 404 0 R /F114 453 0 R /F94 245 0 R >>
 /ProcSet [ /PDF /Text ]
 >>
 endobj
+508 0 obj
+<</Type /StructElem /P 506 0 R /K [ <</Type /MCR /Pg 458  0 R /MCID 471>> <</Type /MCR /Pg 458  0 R /MCID 472>> <</Type /MCR /Pg 458  0 R /MCID 473>> <</Type /MCR /Pg 458  0 R /MCID 474>> <</Type /MCR /Pg 458  0 R /MCID 475>> <</Type /MCR /Pg 458  0 R /MCID 476>> <</Type /MCR /Pg 458  0 R /MCID 477>> <</Type /MCR /Pg 458  0 R /MCID 478>> <</Type /MCR /Pg 458  0 R /MCID 479>> <</Type /MCR /Pg 458  0 R /MCID 480>> <</Type /MCR /Pg 458  0 R /MCID 481>> <</Type /MCR /Pg 458  0 R /MCID 482>> <</Type /MCR /Pg 458  0 R /MCID 483>> <</Type /MCR /Pg 458  0 R /MCID 484>> <</Type /MCR /Pg 458  0 R /MCID 485>> <</Type /MCR /Pg 458  0 R /MCID 486>> <</Type /MCR /Pg 458  0 R /MCID 487>> <</Type /MCR /Pg 458  0 R /MCID 488>> <</Type /MCR /Pg 458  0 R /MCID 489>> <</Type /MCR /Pg 458  0 R /MCID 490>> <</Type /MCR /Pg 458  0 R /MCID 491>> <</Type /MCR /Pg 458  0 R /MCID 492>> <</Type /MCR /Pg 522  0 R /MCID 493>> <</Type /MCR /Pg 522  0 R /MCID 494>>] /S /Code /Lang(EN)  >>
+endobj
 506 0 obj
-<</Type /StructElem /P 504 0 R /K [ <</Type /MCR /Pg 456  0 R /MCID 471>> <</Type /MCR /Pg 456  0 R /MCID 472>> <</Type /MCR /Pg 456  0 R /MCID 473>> <</Type /MCR /Pg 456  0 R /MCID 474>> <</Type /MCR /Pg 456  0 R /MCID 475>> <</Type /MCR /Pg 456  0 R /MCID 476>> <</Type /MCR /Pg 456  0 R /MCID 477>> <</Type /MCR /Pg 456  0 R /MCID 478>> <</Type /MCR /Pg 456  0 R /MCID 479>> <</Type /MCR /Pg 456  0 R /MCID 480>> <</Type /MCR /Pg 456  0 R /MCID 481>> <</Type /MCR /Pg 456  0 R /MCID 482>> <</Type /MCR /Pg 456  0 R /MCID 483>> <</Type /MCR /Pg 456  0 R /MCID 484>> <</Type /MCR /Pg 456  0 R /MCID 485>> <</Type /MCR /Pg 456  0 R /MCID 486>> <</Type /MCR /Pg 456  0 R /MCID 487>> <</Type /MCR /Pg 456  0 R /MCID 488>> <</Type /MCR /Pg 456  0 R /MCID 489>> <</Type /MCR /Pg 456  0 R /MCID 490>> <</Type /MCR /Pg 456  0 R /MCID 491>> <</Type /MCR /Pg 456  0 R /MCID 492>> <</Type /MCR /Pg 520  0 R /MCID 493>> <</Type /MCR /Pg 520  0 R /MCID 494>>] /S /Code /Lang(EN)  >>
+<</Type /StructElem /P 477 0 R /T (The final preamble) /Lang(EN)/K [ 507 0 R 508 0 R] /S /Subsection>>
 endobj
-504 0 obj
-<</Type /StructElem /P 475 0 R /T (The final preamble) /Lang(EN)/K [ 505 0 R 506 0 R] /S /Subsection>>
-endobj
-475 0 obj
-<</Type /StructElem /P 62 0 R /T (Unified source document) /Lang(EN)/K [ 476 0 R 477 0 R 478 0 R 487 0 R 488 0 R 491 0 R 492 0 R 504 0 R] /S /Section>>
-endobj
-522 0 obj
-<</Type /StructElem /P 521 0 R /K [ <</Type /MCR /Pg 520  0 R /MCID 495>>] /S /H /Lang(EN)  >>
+477 0 obj
+<</Type /StructElem /P 64 0 R /T (Unified source document) /Lang(EN)/K [ 478 0 R 479 0 R 480 0 R 489 0 R 490 0 R 493 0 R 494 0 R 506 0 R] /S /Section>>
 endobj
 524 0 obj
-<</Type /StructElem /P 523 0 R /K [<</Type /MCR /Pg 520  0 R /MCID 497>> <</Type /OBJR /Obj 525 0 R>>] /S /Reference>>
-endobj
-523 0 obj
-<</Type /StructElem /P 521 0 R /K [ <</Type /MCR /Pg 520  0 R /MCID 496>>524 0 R   <</Type /MCR /Pg 520  0 R /MCID 498>>] /S /P /Lang(EN)>>
-endobj
-521 0 obj
-<</Type /StructElem /P 62 0 R /T (Problems with this approach) /Lang(EN)/K [ 522 0 R 523 0 R] /S /Section>>
-endobj
-527 0 obj
-<</Type /StructElem /P 526 0 R /K [ <</Type /MCR /Pg 520  0 R /MCID 499>>] /S /H /Lang(EN)  >>
-endobj
-529 0 obj
-<</Type /StructElem /P 528 0 R /K <</Type /MCR /Pg 520  0 R /MCID 501>> /S /Span  /Lang(EN)  >>
-endobj
-530 0 obj
-<</Type /StructElem /P 528 0 R /K <</Type /MCR /Pg 520  0 R /MCID 503>> /S /Span  /Lang(EN)  >>
-endobj
-531 0 obj
-<</Type /StructElem /P 528 0 R /K <</Type /MCR /Pg 520  0 R /MCID 505>> /S /Span  /Lang(EN)  >>
-endobj
-532 0 obj
-<</Type /StructElem /P 528 0 R /K <</Type /MCR /Pg 520  0 R /MCID 507>> /S /Span  /Lang(EN)  >>
-endobj
-528 0 obj
-<</Type /StructElem /P 526 0 R /K [ <</Type /MCR /Pg 520  0 R /MCID 500>> 529 0 R <</Type /MCR /Pg 520  0 R /MCID 502>> 530 0 R <</Type /MCR /Pg 520  0 R /MCID 504>> 531 0 R <</Type /MCR /Pg 520  0 R /MCID 506>> 532 0 R <</Type /MCR /Pg 520  0 R /MCID 508>>] /S /P /Lang(EN)>>
+<</Type /StructElem /P 523 0 R /K [ <</Type /MCR /Pg 522  0 R /MCID 495>>] /S /H /Lang(EN)  >>
 endobj
 526 0 obj
-<</Type /StructElem /P 62 0 R /T (Conclusions) /Lang(EN)/K [ 527 0 R 528 0 R] /S /Section>>
+<</Type /StructElem /P 525 0 R /K [<</Type /MCR /Pg 522  0 R /MCID 497>> <</Type /OBJR /Obj 527 0 R>>] /S /Reference>>
 endobj
-534 0 obj
-<</Type /StructElem /P 533 0 R /K [ <</Type /MCR /Pg 520  0 R /MCID 509>>] /S /H /Lang(EN)  >>
+525 0 obj
+<</Type /StructElem /P 523 0 R /K [ <</Type /MCR /Pg 522  0 R /MCID 496>>526 0 R   <</Type /MCR /Pg 522  0 R /MCID 498>>] /S /P /Lang(EN)>>
 endobj
-536 0 obj
-<</Type /StructElem /P 535 0 R /K [<</Type /MCR /Pg 520  0 R /MCID 511>> <</Type /OBJR /Obj 537 0 R>>] /S /Reference>>
+523 0 obj
+<</Type /StructElem /P 64 0 R /T (Problems with this approach) /Lang(EN)/K [ 524 0 R 525 0 R] /S /Section>>
 endobj
-535 0 obj
-<</Type /StructElem /P 533 0 R /K [ <</Type /MCR /Pg 520  0 R /MCID 510>>536 0 R   <</Type /MCR /Pg 520  0 R /MCID 512>>] /S /P /Lang(EN)>>
+529 0 obj
+<</Type /StructElem /P 528 0 R /K [ <</Type /MCR /Pg 522  0 R /MCID 499>>] /S /H /Lang(EN)  >>
+endobj
+531 0 obj
+<</Type /StructElem /P 530 0 R /K <</Type /MCR /Pg 522  0 R /MCID 501>> /S /Span  /Lang(EN)  >>
+endobj
+532 0 obj
+<</Type /StructElem /P 530 0 R /K <</Type /MCR /Pg 522  0 R /MCID 503>> /S /Span  /Lang(EN)  >>
 endobj
 533 0 obj
-<</Type /StructElem /P 62 0 R /T (Acknowledgements) /Lang(EN)/K [ 534 0 R 535 0 R] /S /Section>>
+<</Type /StructElem /P 530 0 R /K <</Type /MCR /Pg 522  0 R /MCID 505>> /S /Span  /Lang(EN)  >>
 endobj
-62 0 obj
-<</Type /StructElem /P 4 0 R  /Lang(EN)/K [ 63 0 R 73 0 R 74 0 R 133 0 R 178 0 R 191 0 R 475 0 R 521 0 R 526 0 R 533 0 R] /S /Document>>
+534 0 obj
+<</Type /StructElem /P 530 0 R /K <</Type /MCR /Pg 522  0 R /MCID 507>> /S /Span  /Lang(EN)  >>
+endobj
+530 0 obj
+<</Type /StructElem /P 528 0 R /K [ <</Type /MCR /Pg 522  0 R /MCID 500>> 531 0 R <</Type /MCR /Pg 522  0 R /MCID 502>> 532 0 R <</Type /MCR /Pg 522  0 R /MCID 504>> 533 0 R <</Type /MCR /Pg 522  0 R /MCID 506>> 534 0 R <</Type /MCR /Pg 522  0 R /MCID 508>>] /S /P /Lang(EN)>>
+endobj
+528 0 obj
+<</Type /StructElem /P 64 0 R /T (Conclusions) /Lang(EN)/K [ 529 0 R 530 0 R] /S /Section>>
+endobj
+536 0 obj
+<</Type /StructElem /P 535 0 R /K [ <</Type /MCR /Pg 522  0 R /MCID 509>>] /S /H /Lang(EN)  >>
 endobj
 538 0 obj
+<</Type /StructElem /P 537 0 R /K [<</Type /MCR /Pg 522  0 R /MCID 511>> <</Type /OBJR /Obj 539 0 R>>] /S /Reference>>
+endobj
+537 0 obj
+<</Type /StructElem /P 535 0 R /K [ <</Type /MCR /Pg 522  0 R /MCID 510>>538 0 R   <</Type /MCR /Pg 522  0 R /MCID 512>>] /S /P /Lang(EN)>>
+endobj
+535 0 obj
+<</Type /StructElem /P 64 0 R /T (Acknowledgements) /Lang(EN)/K [ 536 0 R 537 0 R] /S /Section>>
+endobj
+64 0 obj
+<</Type /StructElem /P 4 0 R  /Lang(EN)/K [ 65 0 R 75 0 R 76 0 R 135 0 R 180 0 R 193 0 R 477 0 R 523 0 R 528 0 R 535 0 R] /S /Document>>
+endobj
+540 0 obj
 <</Normal <</O /Layout /EndIndent 0.0 /SpaceAfter 0.0 /SpaceBefore 0.0 /StartIndent 0.0 /WritingMode /LrTb /TextAlign /Start>> /CM1 <</O /Layout /TextAlign /Justify>> /CM2 <</O /Layout /TextAlign /Center>> /CM3 <</O /Layout /TextAlign /Start>> /CM4 <</O /Layout /InlineAlign /Center /Placement /Block /SpaceAfter 12.125 /BBox [266 314 329 336]>> >>
 endobj
 4 0 obj
-<</Type /StructTreeRoot /RoleMap 539 0 R /ClassMap 538 0 R /ParentTree <</Nums [0 [ 62 0 R]]>> /ParentTreeNextKey 1 /K [ 62 0 R] >>
+<</Type /StructTreeRoot /RoleMap 541 0 R /ClassMap 540 0 R /ParentTree <</Nums [0 [ 64 0 R]]>> /ParentTreeNextKey 1 /K [ 64 0 R] >>
 endobj
 1 0 obj
 <<>>
@@ -7550,7 +7560,7 @@ endobj
 3 0 obj
 <<  /pgfprgb [/Pattern /DeviceRGB] >>
 endobj
-541 0 obj
+543 0 obj
 <<
 /Length 11181     
 >>
@@ -7566,11 +7576,11 @@ EMC
 /P <</MCID 493>> BDC
 1 0 0 1 -72 -663.078 cm
 BT
-/F113 8.9664 Tf/F82 1 Tf( )Tj/F113 8.9664 Tf 73.444 663.078 Td [(\134)]TJ
+/F114 8.9664 Tf/F84 1 Tf( )Tj/F114 8.9664 Tf 73.444 663.078 Td [(\134)]TJ
 0 0 1 rg 0 0 1 RG
-/F82 1 Tf( )Tj/F113 8.9664 Tf 4.764 0 Td [(b)-92(e)-93(g)-92(i)-92(n)]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 4.764 0 Td [(b)-92(e)-93(g)-92(i)-92(n)]TJ
 0 g 0 G
-/F82 1 Tf( )Tj/F113 8.9664 Tf 27.264 0 Td [({)-178(d)-46(o)-45(c)-46(u)-45(m)-46(e)-45(n)-46(t)-178(})]TJ
+/F84 1 Tf( )Tj/F114 8.9664 Tf 27.264 0 Td [({)-178(d)-46(o)-45(c)-46(u)-45(m)-46(e)-45(n)-46(t)-178(})]TJ
 0 g 0 G
 0 g 0 G
 0 g 0 G
@@ -7583,7 +7593,7 @@ EMC
 /H <</MCID 495>> BDC
 1 0 0 1 -72 -637.176 cm
 BT
-/F81 11.9552 Tf/F82 1 Tf( )Tj/F81 11.9552 Tf 72 637.176 Td [(5)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 18.602 0 Td [(Pr)20(ob)10(lems)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 57.444 0 Td [(with)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 27.233 0 Td [(this)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 24.58 0 Td [(appr)20(oac)10(h)]TJ
+/F83 11.9552 Tf/F84 1 Tf( )Tj/F83 11.9552 Tf 72 637.176 Td [(5)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 18.602 0 Td [(Pr)20(ob)10(lems)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 57.444 0 Td [(with)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 27.233 0 Td [(this)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 24.58 0 Td [(appr)20(oac)10(h)]TJ
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 g 0 G
@@ -7594,13 +7604,13 @@ EMC
 /P <</MCID 496>> BDC
 1 0 0 1 -72 -618.122 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 618.122 Td [(W)80(ell,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.551 0 Td [(there)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.406 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(lots.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.975 0 Td [(If)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.125 0 Td [(you)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(\002nd)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.993 0 Td [(an)15(y)65(,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.57 0 Td [(please)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.387 0 Td [(use)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.771 0 Td [(GitHub')55(s)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 618.122 Td [(W)80(ell,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.551 0 Td [(there)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.406 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(lots.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.975 0 Td [(If)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.125 0 Td [(you)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(\002nd)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.993 0 Td [(an)15(y)65(,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.57 0 Td [(please)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.387 0 Td [(use)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.771 0 Td [(GitHub')55(s)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -186.868 -11.955 Td [(issue)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.416 0 Td [(tracking)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.137 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(report)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.281 0 Td [(these.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.052 0 Td [(Y)110(ou)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.55 0 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(\002nd)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.993 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.664 0 Td [(cur)20(-)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -186.868 -11.955 Td [(issue)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.416 0 Td [(tracking)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.137 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(report)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.281 0 Td [(these.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.052 0 Td [(Y)110(ou)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.55 0 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(\002nd)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.993 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.664 0 Td [(cur)20(-)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -187.654 -11.955 Td [(rent)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.982 0 Td [(list)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.675 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(issues)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.291 0 Td [(at)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -187.654 -11.955 Td [(rent)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.982 0 Td [(list)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.675 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(issues)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.291 0 Td [(at)]TJ
 ET
 1 0 0 1 151.421 594.212 cm
 EMC
@@ -7608,13 +7618,13 @@ EMC
 0 g 0 G
 1 0 0 1 -151.421 -594.212 cm
 BT
-/F101 9.9626 Tf/F82 1 Tf( )Tj/F101 9.9626 Tf 151.421 594.212 Td [(https://github.com/)]TJ
+/F102 9.9626 Tf/F84 1 Tf( )Tj/F102 9.9626 Tf 151.421 594.212 Td [(https://github.com/)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F101 9.9626 Tf -79.421 -11.955 Td [(AndyClifton/AccessibleMetaClass/)]TJ
+/F84 1 Tf( )Tj/F102 9.9626 Tf -79.421 -11.955 Td [(AndyClifton/AccessibleMetaClass/)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F101 9.9626 Tf 0 -11.956 Td [(issues)]TJ
+/F84 1 Tf( )Tj/F102 9.9626 Tf 0 -11.956 Td [(issues)]TJ
 0 g 0 G
 ET
 1 0 0 1 107.865 570.301 cm
@@ -7622,7 +7632,7 @@ EMC
 /P <</MCID 498>> BDC
 1 0 0 1 -107.865 -570.301 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 107.865 570.301 Td [(.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 107.865 570.301 Td [(.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -7633,7 +7643,7 @@ EMC
 /H <</MCID 499>> BDC
 1 0 0 1 -72 -535.806 cm
 BT
-/F81 11.9552 Tf/F82 1 Tf( )Tj/F81 11.9552 Tf 72 535.806 Td [(6)]TJ/F82 1 Tf( )Tj/F81 11.9552 Tf 18.602 0 Td [(Conc)20(lusions)]TJ
+/F83 11.9552 Tf/F84 1 Tf( )Tj/F83 11.9552 Tf 72 535.806 Td [(6)]TJ/F84 1 Tf( )Tj/F83 11.9552 Tf 18.602 0 Td [(Conc)20(lusions)]TJ
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 g 0 G
@@ -7644,70 +7654,70 @@ EMC
 /P <</MCID 500>> BDC
 1 0 0 1 -72 -516.752 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 516.752 Td [(In)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(order)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.512 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(generate)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.233 0 Td [(accessible)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 516.752 Td [(In)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(order)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.512 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(generate)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.233 0 Td [(accessible)]TJ
 ET
 1 0 0 1 195.655 516.752 cm
 EMC
 /Span <</MCID 501>> BDC
 1 0 0 1 -195.655 -516.752 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 195.655 516.752 Td [(.pdf)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 195.655 516.752 Td [(.pdf)]TJ
 ET
 1 0 0 1 212.332 516.752 cm
 EMC
 /P <</MCID 502>> BDC
 1 0 0 1 -212.332 -516.752 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 214.823 516.752 Td [(\002les)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.098 0 Td [(with)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(L)]TJ/F79 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.684 0 Td [(that)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 214.823 516.752 Td [(\002les)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.098 0 Td [(with)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(L)]TJ/F80 7.3723 Tf 2.5 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.829 -1.487 Td [(T)]TJ 4.426 -2.241 Td [(E)]TJ 4.842 2.241 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.684 0 Td [(that)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -207.406 -11.955 Td [(can)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.319 0 Td [(also)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 18.54 0 Td [(be)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 11.895 0 Td [(shared)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.493 0 Td [(with)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(WYSIWYG)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 51.736 0 Td [(w)10(ord)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 22.864 0 Td [(processor)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -207.406 -11.955 Td [(can)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.319 0 Td [(also)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 18.54 0 Td [(be)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 11.895 0 Td [(shared)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.493 0 Td [(with)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(WYSIWYG)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 51.736 0 Td [(w)10(ord)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 22.864 0 Td [(processor)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -170.051 -11.955 Td [(users,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.454 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(L)]TJ/F79 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.427 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 9.683 0 Td [(meta)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(class)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.857 0 Td [(w)10(as)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.883 0 Td [(created.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 34.341 0 Td [(This)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(meta)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(class)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -170.051 -11.955 Td [(users,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.454 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(L)]TJ/F80 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.427 -2.242 Td [(E)]TJ 4.842 2.242 Td [(X)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 9.683 0 Td [(meta)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(class)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.857 0 Td [(w)10(as)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.883 0 Td [(created.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 34.341 0 Td [(This)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(meta)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(class)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -195.65 -11.955 Td [(uses)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.646 0 Td [(a)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 6.914 0 Td [(well-de\002ned)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 52.293 0 Td [(set)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 13.559 0 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.79 0 Td [(packages)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.003 0 Td [(that)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.435 0 Td [(limits)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.194 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(scope)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -195.65 -11.955 Td [(uses)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.646 0 Td [(a)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 6.914 0 Td [(well-de\002ned)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 52.293 0 Td [(set)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 13.559 0 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.79 0 Td [(packages)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.003 0 Td [(that)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.435 0 Td [(limits)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.194 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(scope)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -199.499 -11.955 Td [(of)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.789 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(casual)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.387 0 Td [(')18(te)15(x)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 17.654 0 Td [(author)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.945 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.241 0 Td [(\002ddle,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.676 0 Td [(whilst)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.849 0 Td [(gi)25(ving)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.706 0 Td [(the)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -199.499 -11.955 Td [(of)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.789 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(casual)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.387 0 Td [(')18(te)15(x)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 17.654 0 Td [(author)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.945 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.241 0 Td [(\002ddle,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.676 0 Td [(whilst)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.849 0 Td [(gi)25(ving)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.706 0 Td [(the)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -190.912 -11.956 Td [(author)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 27.945 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(tools)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.867 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(create)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.271 0 Td [(comple)15(x)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 36.652 0 Td [(technical)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 38.456 0 Td [(documents.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -190.912 -11.956 Td [(author)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 27.945 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(tools)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.867 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(create)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.271 0 Td [(comple)15(x)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 36.652 0 Td [(technical)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 38.456 0 Td [(documents.)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -176.098 -11.955 Td [(Accessible)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -176.098 -11.955 Td [(Accessible)]TJ
 ET
 1 0 0 1 117.648 445.021 cm
 EMC
 /Span <</MCID 503>> BDC
 1 0 0 1 -117.648 -445.021 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 117.648 445.021 Td [(.pdf)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 117.648 445.021 Td [(.pdf)]TJ
 ET
 1 0 0 1 134.325 445.021 cm
 EMC
 /P <</MCID 504>> BDC
 1 0 0 1 -134.325 -445.021 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 136.816 445.021 Td [(\002les)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.098 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(compiled)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.571 0 Td [(directly)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 32.926 0 Td [(from)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(the)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 136.816 445.021 Td [(\002les)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.098 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(compiled)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.571 0 Td [(directly)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 32.926 0 Td [(from)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(the)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -192.924 -11.955 Td [(L)]TJ/F79 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F79 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(Xsource)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.686 0 Td [(code,)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 23.791 0 Td [(while)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -192.924 -11.955 Td [(L)]TJ/F80 7.3723 Tf 2.501 1.487 Td [(A)]TJ/F80 9.9626 Tf 3.828 -1.487 Td [(T)]TJ 4.426 -2.242 Td [(E)]TJ 4.842 2.242 Td [(Xsource)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.686 0 Td [(code,)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 23.791 0 Td [(while)]TJ
 ET
 1 0 0 1 171.701 433.066 cm
 EMC
 /Span <</MCID 505>> BDC
 1 0 0 1 -171.701 -433.066 cm
 BT
-/F85 9.9626 Tf/F82 1 Tf( )Tj/F85 9.9626 Tf 171.701 433.066 Td [(.rtf)]TJ
+/F87 9.9626 Tf/F84 1 Tf( )Tj/F87 9.9626 Tf 171.701 433.066 Td [(.rtf)]TJ
 ET
 1 0 0 1 185.061 433.066 cm
 EMC
 /P <</MCID 506>> BDC
 1 0 0 1 -185.061 -433.066 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 187.551 433.066 Td [(\002les)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 19.098 0 Td [(are)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.655 0 Td [(written)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 30.715 0 Td [(using)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 24.079 0 Td [(the)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 187.551 433.066 Td [(\002les)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 19.098 0 Td [(are)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.655 0 Td [(written)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 30.715 0 Td [(using)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 24.079 0 Td [(the)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -7716,17 +7726,17 @@ EMC
 /Span <</MCID 507>> BDC
 1 0 0 1 -72 -421.111 cm
 BT
-/F91 9.9626 Tf/F82 1 Tf( )Tj/F91 9.9626 Tf 72 421.111 Td [(latex2rtf)]TJ
+/F93 9.9626 Tf/F84 1 Tf( )Tj/F93 9.9626 Tf 72 421.111 Td [(latex2rtf)]TJ
 ET
 1 0 0 1 107.994 421.111 cm
 EMC
 /P <</MCID 508>> BDC
 1 0 0 1 -107.994 -421.111 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 110.485 421.111 Td [(program.)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 39.332 0 Td [(This)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(meets)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 25.733 0 Td [(the)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.665 0 Td [(users')]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.281 0 Td [(need)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.3 0 Td [(for)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 14.107 0 Td [(a)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 110.485 421.111 Td [(program.)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 39.332 0 Td [(This)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(meets)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 25.733 0 Td [(the)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.665 0 Td [(users')]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.281 0 Td [(need)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.3 0 Td [(for)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 14.107 0 Td [(a)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -200.107 -11.955 Td [(single)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 26.291 0 Td [(source)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 28.493 0 Td [(\002le)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 15.223 0 Td [(and)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 16.876 0 Td [(minimal)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 35.706 0 Td [(interv)15(ention.)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -200.107 -11.955 Td [(single)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 26.291 0 Td [(source)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 28.493 0 Td [(\002le)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 15.223 0 Td [(and)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 16.876 0 Td [(minimal)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 35.706 0 Td [(interv)15(ention.)]TJ
 0 g 0 G
 0 g 0 G
 ET
@@ -7737,7 +7747,7 @@ EMC
 /H <</MCID 509>> BDC
 1 0 0 1 -72 -374.66 cm
 BT
-/F81 11.9552 Tf/F82 1 Tf( )Tj/F81 11.9552 Tf 72 374.66 Td [(Ac)20(kno)15(wledg)-10(ements)]TJ
+/F83 11.9552 Tf/F84 1 Tf( )Tj/F83 11.9552 Tf 72 374.66 Td [(Ac)20(kno)15(wledg)-10(ements)]TJ
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 0.47452 0.75687 rg 0 0.47452 0.75687 RG
 0 g 0 G
@@ -7748,10 +7758,10 @@ EMC
 /P <</MCID 510>> BDC
 1 0 0 1 -72 -355.607 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 72 355.607 Td [(This)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 20.204 0 Td [(document)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(bene\002tted)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 41.783 0 Td [(from)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 21.858 0 Td [(contrib)20(utions)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 54.873 0 Td [(to)]TJ/F82 1 Tf( )Tj/F79 9.9626 Tf 10.242 0 Td [(the)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 72 355.607 Td [(This)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 20.204 0 Td [(document)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(bene\002tted)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 41.783 0 Td [(from)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 21.858 0 Td [(contrib)20(utions)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 54.873 0 Td [(to)]TJ/F84 1 Tf( )Tj/F80 9.9626 Tf 10.242 0 Td [(the)]TJ
 0 g 0 G
 0 g 0 G
-/F82 1 Tf( )Tj/F79 9.9626 Tf -190.743 -11.956 Td [(website,)]TJ
+/F84 1 Tf( )Tj/F80 9.9626 Tf -190.743 -11.956 Td [(website,)]TJ
 ET
 1 0 0 1 107.417 343.651 cm
 EMC
@@ -7759,7 +7769,7 @@ EMC
 0 g 0 G
 1 0 0 1 -107.417 -343.651 cm
 BT
-/F101 9.9626 Tf/F82 1 Tf( )Tj/F101 9.9626 Tf 107.417 343.651 Td [(http://tex.stackexchange.com/)]TJ
+/F102 9.9626 Tf/F84 1 Tf( )Tj/F102 9.9626 Tf 107.417 343.651 Td [(http://tex.stackexchange.com/)]TJ
 0 g 0 G
 ET
 1 0 0 1 280.767 343.651 cm
@@ -7767,7 +7777,7 @@ EMC
 /P <</MCID 512>> BDC
 1 0 0 1 -280.767 -343.651 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 280.767 343.651 Td [(.)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 280.767 343.651 Td [(.)]TJ
 0 g 0 G
 ET
 1 0 0 1 72 343.651 cm
@@ -7783,7 +7793,7 @@ EMC
 /Artifact <</Type /Pagination>> BDC
 1 0 0 1 -72 -42.112 cm
 BT
-/F79 9.9626 Tf/F82 1 Tf( )Tj/F79 9.9626 Tf 303.509 42.112 Td [(7)]TJ
+/F80 9.9626 Tf/F84 1 Tf( )Tj/F80 9.9626 Tf 303.509 42.112 Td [(7)]TJ
 ET
 1 0 0 1 540 42.112 cm
 EMC
@@ -7791,20 +7801,20 @@ EMC
 
 endstream
 endobj
-520 0 obj
+522 0 obj
 <<
 /Type /Page
-/Contents 541 0 R
-/Resources 540 0 R
+/Contents 543 0 R
+/Resources 542 0 R
 /MediaBox [0 0 612 792]
-/Parent 548 0 R
-/Annots [ 525 0 R 543 0 R 544 0 R 545 0 R 546 0 R 537 0 R ]
+/Parent 550 0 R
+/Annots [ 527 0 R 545 0 R 546 0 R 547 0 R 548 0 R 539 0 R ]
 >>
 endobj
-539 0 obj
+541 0 obj
 <</IndexItem /Span /TOF /TOC /TOFI /TOCI /TOT /TOC /TOTI /TOCI /Titlepage /Sect /Bibliography /L /BibItem /LI /ParagraphSpan /Span /Footnote /Note /Chapter /Sect/Section /Sect/Subsection /Sect/Subsubsection /Sect/Float /Div/L1 /L/L2 /L/L3 /L/L4 /L/L5 /L>>
 endobj
-525 0 obj
+527 0 obj
 <<
 /Type /Annot
 /Border[0 0 0]/H/I/C[0 1 1]
@@ -7812,7 +7822,7 @@ endobj
 /Subtype/Link/F 4/A<</Type/Action/S/URI/URI(https://github.com/AndyClifton/AccessibleMetaClass/issues)>>
 >>
 endobj
-543 0 obj
+545 0 obj
 <<
 /Type /Annot
 /Border[0 0 0]/H/I/C[0 1 1]
@@ -7820,7 +7830,7 @@ endobj
 /Subtype/Link/F 4/A<</Type/Action/S/URI/URI(https://github.com/AndyClifton/AccessibleMetaClass/issues)>>
 >>
 endobj
-544 0 obj
+546 0 obj
 <<
 /Type /Annot
 /Border[0 0 0]/H/I/C[0 1 1]
@@ -7828,7 +7838,7 @@ endobj
 /Subtype/Link/F 4/A<</Type/Action/S/URI/URI(https://github.com/AndyClifton/AccessibleMetaClass/issues)>>
 >>
 endobj
-545 0 obj
+547 0 obj
 <<
 /Type /Annot
 /Border[0 0 0]/H/I/C[0 1 1]
@@ -7836,7 +7846,7 @@ endobj
 /Subtype/Link/F 4/A<</Type/Action/S/URI/URI(https://github.com/AndyClifton/AccessibleMetaClass/issues)>>
 >>
 endobj
-546 0 obj
+548 0 obj
 <<
 /Type /Annot
 /Border[0 0 0]/H/I/C[0 1 1]
@@ -7844,7 +7854,7 @@ endobj
 /Subtype/Link/F 4/A<</Type/Action/S/URI/URI(https://github.com/AndyClifton/AccessibleMetaClass/issues)>>
 >>
 endobj
-537 0 obj
+539 0 obj
 <<
 /Type /Annot
 /Border[0 0 0]/H/I/C[0 1 1]
@@ -7852,73 +7862,73 @@ endobj
 /Subtype/Link/F 4/A<</Type/Action/S/URI/URI(http://tex.stackexchange.com/)>>
 >>
 endobj
+544 0 obj
+<<
+/D [522 0 R /XYZ 71 718.907 null]
+>>
+endobj
+55 0 obj
+<<
+/D [522 0 R /XYZ 72 655.106 null]
+>>
+endobj
+59 0 obj
+<<
+/D [522 0 R /XYZ 72 555.577 null]
+>>
+endobj
+549 0 obj
+<<
+/D [522 0 R /XYZ 72 388.608 null]
+>>
+endobj
 542 0 obj
 <<
-/D [520 0 R /XYZ 71 718.907 null]
->>
-endobj
-53 0 obj
-<<
-/D [520 0 R /XYZ 72 655.106 null]
->>
-endobj
-57 0 obj
-<<
-/D [520 0 R /XYZ 72 555.577 null]
->>
-endobj
-547 0 obj
-<<
-/D [520 0 R /XYZ 72 388.608 null]
->>
-endobj
-540 0 obj
-<<
  /ColorSpace 3 0 R /Pattern 2 0 R /ExtGState 1 0 R 
-/Font << /F113 451 0 R /F82 145 0 R /F81 144 0 R /F79 141 0 R /F101 398 0 R /F85 146 0 R /F91 235 0 R >>
+/Font << /F114 453 0 R /F84 147 0 R /F83 146 0 R /F80 143 0 R /F102 400 0 R /F87 148 0 R /F93 237 0 R >>
 /ProcSet [ /PDF /Text ]
 >>
 endobj
-551 0 obj
+553 0 obj
 [889 667 222 333 333 389 584 278 333 278 278 556 556 556 556 556 556 556 556 556 556 278 278 584 584 584 556 1015 667 667 722 722 667 611 778 722 278 500 667 556 833 722 778 667 778 722 667 611 722 667 944 667 667 611 278 278 278 469 556 222 556 556 500 556 556 278 556 556 222 222 500 222 833 556 556 556 556 333 500 278 556 500 722 500 500 500 334 260 334]
 endobj
-552 0 obj
+554 0 obj
 [833.3]
 endobj
-553 0 obj
+555 0 obj
 [600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600]
 endobj
-554 0 obj
+556 0 obj
 [777.8 277.8 333.3 277.8 500 500 500 500 500 500 500 500 500 500 500 277.8 277.8 277.8 777.8]
 endobj
-555 0 obj
+557 0 obj
 [278 278 556 556 556 556 556 556 556 556 556 556 278 278 584 584 584 556 1015 667 667 722 722 667 611 778 722 278 500 667 556 833 722 778 667 778 722 667 611 722 667 944 667 667 611 278 278 278 469 556 222 556 556 500 556 556 278 556 556 222 222 500 222 833 556 556 556 556 333 500 278 556 500 722 500]
 endobj
-556 0 obj
+558 0 obj
 [600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600]
 endobj
-557 0 obj
+559 0 obj
 [611 611 167 333 611 278 333 333 0 333 584 0 611 500 333 278 0 0 0 0 0 0 0 0 0 0 0 0 333 238 278 333 474 556 556 889 722 278 333 333 389 584 278 333 278 278 556 556 556 556 556 556 556 556 556 556 333 333 584 584 584 611 975 722 722 722 722 667 611 778 722 278 556 722 611 833 722 778 667 778 722 667 611 722 667 944 667 667 611 333 278 333 584 556 278 556 611 556 611 556 333 611 611 278 278 556 278 889 611 611 611 611 389 556 333 611 556 778 556 556 500 389 280 389 584 0 0 0 278 556 500 1000 556 556 333 1000 667 333 1000 0 0 0 0 0 0 500 500]
 endobj
-558 0 obj
+560 0 obj
 [556 167 333 611 278 333 333 0 333 606 0 611 389 333 278 0 0 0 0 0 0 0 0 0 0 0 0 333 278 250 389 555 500 500 833 778 333 333 333 500 570 250 333 250 278 500 500 500 500 500 500 500 500 500 500 333 333 570 570 570 500 832 667 667 667 722 667 667 722 778 389 500 667 611 889 722 722 611 722 667 556 611 722 667 889 667 611 611 333 278 333 570 500 333 500 500 444 500 444 333 500 556 278 278 500 278 778 556 500 500 500 389 389 278 556 444 667 500 444]
 endobj
-559 0 obj
+561 0 obj
 [556 556 167 333 667 278 333 333 0 333 570 0 667 444 333 278 0 0 0 0 0 0 0 0 0 0 0 0 333 278 250 333 555 500 500 1000 833 333 333 333 500 570 250 333 250 278 500 500 500 500 500 500 500 500 500 500 333 333 570 570 570 500 930 722 667 722 722 667 611 778 778 389 500 778 667 944 722 778 611 778 722 556 667 722 722 1000 722 722 667 333 278 333 581 500 333 500 556 444 556 444 333 500 556 278 333 556 278 833 556 500 556 556 444 389 333 556 500 722 500 500]
 endobj
-560 0 obj
+562 0 obj
 [500 675 250 333 250 278 500 500 500 500 500 500 500 500 500 500 333 333 675 675 675 500 920 611 611 667 722 611 611 722 722 333 444 667 556 833 667 722 611 722 611 500 556 722 611 833 611 556 556 389 278 389 422 500 333 500 500 444 500 444 278 500 500 278 278 444 278 722 500 500 500 500 389 389 278 500 444 667 444 444]
 endobj
-561 0 obj
+563 0 obj
 [1]
 endobj
-562 0 obj
+564 0 obj
 [611 611 167 333 611 278 333 333 0 333 584 0 611 500 333 278 0 0 0 0 0 0 0 0 0 0 0 0 333 238 278 333 474 556 556 889 722 278 333 333 389 584 278 333 278 278 556 556 556 556 556 556 556 556 556 556 333 333 584 584 584 611 975 722 722 722 722 667 611 778 722 278 556 722 611 833 722 778 667 778 722 667 611 722 667 944 667 667 611 333 278 333 584 556 278 556 611 556 611 556 333 611 611 278 278 556 278 889 611 611 611 611 389 556 333 611 556 778 556 556]
 endobj
-563 0 obj
+565 0 obj
 [556 556 167 333 611 278 333 333 0 333 564 0 611 444 333 278 0 0 0 0 0 0 0 0 0 0 0 0 333 180 250 333 408 500 500 833 778 333 333 333 500 564 250 333 250 278 500 500 500 500 500 500 500 500 500 500 278 278 564 564 564 444 921 722 667 667 722 611 556 722 722 333 389 722 611 889 722 722 556 722 667 556 611 722 722 944 722 722 611 333 278 333 469 500 333 444 500 444 500 444 333 500 500 278 278 500 278 778 500 500 500 500 333 389 278 500 500 722 500 500 444 480 200 480 541 0 0 0 333 500 444 1000 500 500 333 1000 556 333 889 0 0 0 0 0 0 444 444 350 500]
 endobj
-564 0 obj
+566 0 obj
 <<
 /Length1 1384
 /Length2 6013
@@ -7996,7 +8006,7 @@ KG7è„"≠|Q–áÊ™˙Â ZÚzs|ÖÇ}£ƒL’¥Sä•:Äf™’mºß¬A3Ôè÷S2ƒ=ë÷[≥d∑ÿì¸Jú\‹≥≠ÚcÏ⁄
 ﬂB≤üh á¶„Ω´ròKπäºÏ}⁄QO 7y¥ ll¨6	ÂH≤ê…¥ˇﬁ ¨˜Ñû¯Z«à∂¿ÿÏ+oèL…_gΩRæØÏ1+`ˆfKˆu‚∂`!Á¥˘íR¯˙„8té¬,m‘©KûëÓ3›A»AÄ|ÉŸy]/∆Ö%)`G∏ÂÙ¯[
 endstream
 endobj
-565 0 obj
+567 0 obj
 <<
 /Type /FontDescriptor
 /FontName /RFLZJB+CMR10
@@ -8009,10 +8019,10 @@ endobj
 /StemV 69
 /XHeight 431
 /CharSet (/equal/plus)
-/FontFile 564 0 R
+/FontFile 566 0 R
 >>
 endobj
-566 0 obj
+568 0 obj
 <<
 /Length1 839
 /Length2 980
@@ -8056,7 +8066,7 @@ n›ùÆz)ç=‹3¨Õw }®"´ãp7ç`¯Â›8˜œ†0 ∆ËÇôÛL¨øC≥¡E˝ÆêÖwRDÖ¡éAµ5∫ëó#ÛÉ˘¨∞Í÷yÔ:#
 @ﬁãïÜhº7•Õ˝¥SDÚ‹J6^^øà1|%∑éŒ–5;N ƒ´¢dp!\?:ÏLÒvpÉ?ç˘á£po“Zº∫˜ü—ÂÄ”_P´å∫˙#√‰8⁄»›i$^AB∆5¿>∑	$∑˝YˆÁîsö≤ZH¡9
 endstream
 endobj
-567 0 obj
+569 0 obj
 <<
 /Type /FontDescriptor
 /FontName /FRJGEQ+DummySpace
@@ -8069,10 +8079,10 @@ endobj
 /StemV 0
 /XHeight 400
 /CharSet (/space)
-/FontFile 566 0 R
+/FontFile 568 0 R
 >>
 endobj
-568 0 obj
+570 0 obj
 <<
 /Length1 1309
 /Length2 5938
@@ -8139,7 +8149,7 @@ E∫Yƒˆ-”îÓ]ÿÒÆæ™"më¢s$ãŒíÍLãps“–"$t«´ò˘øêçP·h+¶J¥æ∂ì¡Í˚æ∂ãì‘j	Â[≠ã_[“å*7Ÿ {Ë
 è)á∞ﬂr¨OrÏjk«∞.÷†Rà⁄™	QÌÉÏåMähã>¢aà®Í<9'≠"¡Æ±E” ñS}µI˝n∫ÚBÎ`*m04Âå∆ƒöZ»ª,ä•™øqÇëk–4ã5‚QºÌ$Í3Q«¢Pô⁄û%œ´œS∫>√T\tÜri‘º›∫≈Àƒl˛cÿÓ5thªõ–âŒ¿S°≤c3Ô-Z™*ùìú≤E¢Å≈DÊ{D#ÖÎ ÀX±∫WÛëãìkE¿.ÅÀ•lò‘1Q{Õ≠ÎëgYéë\A%iúﬂ\8fíÔπ®‚5±Á«JÒ¯kÆ«Ì.EtÄÛ´,3I•è≥#k(œ'›≥SÿßY⁄êÚπï7 i&,Õ6J≤∂nK04úáƒdzÂ.Æ/7v$M◊c‰ìı;∏≥ªŸ| L\ 59—ı∑/Ñ¡|ibC±`ˇDˆÖÏ—J√"µá≤vbg}|´"D<§=â¨ÿÌÍ®äIÿµõ˜D}©A‹ãªôx”π˙7Ëé?,_ÒÖß/ã!÷Hl‘Ä∆à.º&Ìà©LêΩÕS	ˇét∫πΩπ¶„uÄ	p◊i4¢8ØÓ[vCmeõLÃäVîùKÉ≠TS⁄º®Qo÷¢QÄœÍYúHè.l∂9ætöÆ∂≥“l;ËÅ≤KSûøÊÓƒLREà4ír7(ìR,]cb’,„AWm±ÆénÔ%ÍÖ“äÈΩ≈g´é˙>%≈¡ìÄÅqUó¿¯ü""n≥<|yº\˚xÄS¨ºÆqæA8¯ΩÖ≥πË π(RsB√j&E;5u`Aπ„ûL¢˙¯!Y∏˙Ä…–'ßÈ-C˜i."Â¯˝œÙ∆>%CU7ßÌû6;.[RdWk£œ¥¨'õcÙ◊[eQœ^œÙ;[µ◊q7>º<ƒ>Ô~æ+ã
 endstream
 endobj
-569 0 obj
+571 0 obj
 <<
 /Type /FontDescriptor
 /FontName /RXNEKG+MSAM10
@@ -8152,10 +8162,10 @@ endobj
 /StemV 40
 /XHeight 431
 /CharSet (/check)
-/FontFile 568 0 R
+/FontFile 570 0 R
 >>
 endobj
-570 0 obj
+572 0 obj
 <<
 /Length1 1606
 /Length2 7878
@@ -8230,7 +8240,7 @@ O>w∞Åõ±V6l#v\'“(˙mO¬ﬁ«°*qZ∑–ÒòÖ
 Å,#1HäÜ€ƒ¥Á¸Ô‚x]ßTK+úÕÊmàyµú˝î≠ñÍÆV‹-≥≥¨ú1io4≥i]‘(Sî™˝ºQÇXv9ªf'h1ÕÛs`´u¡µMÙßsRìzù"É«Nê‰ôÙA—ÆékgN_≈ì;/=që∆ÈWîÕ∆•„R∆tj§ˆ`Iœ◊ª≈ﬁÑj3z‰]pLNáheÉù^õcs˚<` Ú§£‘Áº‡„Œln8g˚íØ‚òh@N=Kˆ§è'Ø.ÊJó5†rDN5ìÓMy¬-<~πËbÙäﬁ∫.’ëÉûoòG
 endstream
 endobj
-571 0 obj
+573 0 obj
 <<
 /Type /FontDescriptor
 /FontName /LQLAWZ+NimbusMonL-Bold
@@ -8243,10 +8253,10 @@ endobj
 /StemV 101
 /XHeight 439
 /CharSet (/a/b/backslash/c/d/e/f/i/l/m/n/o/p/r/t/two/u/v/w/x)
-/FontFile 570 0 R
+/FontFile 572 0 R
 >>
 endobj
-572 0 obj
+574 0 obj
 <<
 /Length1 1612
 /Length2 11241
@@ -8348,7 +8358,7 @@ itº« X∏Ë•ﬂç˛[£ê;ÄƒNàñ˘»à„mëd¢‚ƒX?)πƒèOD´cı=?Œá ÌÈC‹Á@‡—ZÔ“WºY?%@ﬁ/2GeÊZ
 7uZ3Tÿ∏5WòVÔôN∑¢]1Æhâ Å˜≈3UYÅ∫#”vÓ˙c¥#™∑Hº=Ø⁄Ú™≈ùŒAƒå∫`Lßˇ^¢´	FÂw∆Íyí ∆∂∏bß ¯Z4/ËZ·Ãxè¢5È[!ûXhƒﬁTß5*‚‡§Ï¿^Wä6mp†ç<7!∫§ngÿx◊p¸“ï%Vπ+Ã ÙyÂ©CsVÅ£Ú≈KÑπw®Õ∏◊‰ÄåDÓ‘ı∫›iÉ*{¯¥ÍqR‘÷ˇ,•o˝˝˘≠∂+È +ëîxp®ÚÚ≤Ñ.QÑÛ#[π¶x∞‹Ω÷9ÖÅ3Œ\˚ÀµzagâA^G@j$¸àSª{`Où38π1e!Z{ùöJ`˝BÈyÉÅÇxTã…2´y—Ñaãß›€°o“X$¥g£ítD:~*eΩXüLÀê$≥ò_Ÿr‹ßÛ4|¿“êÂ≠l±|c^ÕI5Ω^º1’˜íizÊsÅÿÀ&JîÊ Ç5Dôó=6ä$°Gtµø§c7'¢˝jiΩÑÿ•¥=x*≤Wπ0~√º÷Uﬂô§◊qdê›ôtÍù\ÍÉ ﬁt›˘è≈±A1
 endstream
 endobj
-573 0 obj
+575 0 obj
 <<
 /Type /FontDescriptor
 /FontName /RVMJKN+NimbusMonL-Regu
@@ -8361,10 +8371,10 @@ endobj
 /StemV 41
 /XHeight 426
 /CharSet (/A/C/M/a/asciicircum/b/backslash/braceleft/braceright/bracketleft/bracketright/c/colon/comma/d/e/equal/f/g/h/i/k/l/m/n/o/p/period/plus/q/r/s/slash/t/two/u/x/y)
-/FontFile 572 0 R
+/FontFile 574 0 R
 >>
 endobj
-574 0 obj
+576 0 obj
 <<
 /Length1 1608
 /Length2 9041
@@ -8454,7 +8464,7 @@ O°/Å!à˙‘d≠ÿLÚ≤êåTLÇ¸aèVs}ùLG∂£r‹¥¥°óJùû{\≤›Ï£YúIós'BVûåü˘—._Q44j–0W‰—!ò
 ∞˛Sá‰k9*©ï“˘aÈxˆûYñ<’Ñıπ≈òa<é±ño—"ÆÎ¨]J˛ó◊˚1πtøqVA?=™‹FîáN7\±ˆËh‹Bîë>ÎôÎil(¥OJ†Œ¥&Ôz¡#ÍWyYµ úò‘qrMe∏OCªAÎwkôΩPú‰rö$(ìÌÀÀâ‰˝.®]$_±⁄êi¨zV
 endstream
 endobj
-575 0 obj
+577 0 obj
 <<
 /Type /FontDescriptor
 /FontName /JHQXVN+NimbusSanL-Bold
@@ -8467,10 +8477,10 @@ endobj
 /StemV 141
 /XHeight 532
 /CharSet (/A/C/F/I/L/P/R/T/U/a/b/c/comma/d/e/f/fi/five/fl/four/g/h/i/k/l/m/n/o/one/p/parenleft/parenright/period/q/r/s/six/t/three/two/u/w/x/y)
-/FontFile 574 0 R
+/FontFile 576 0 R
 >>
 endobj
-576 0 obj
+578 0 obj
 <<
 /Length1 1625
 /Length2 9200
@@ -8540,7 +8550,7 @@ F¬¸Î´jÍ®Î
 +…Y_(-I„Jπ=<âß@ºÎ∑ûƒÉd¶;]å##ı†¥ôöÅUsi¯N{bÏË˜⁄{ÀP◊¢á,‚ã,ﬂ]åﬁÇ}xªj_‚∆¡ 1ä˙3˘L˝k©˚Ü2ÒÕè•Üπ.ó©ÜÙª’ı˘ΩÛ¸vÇâ<;‘√q[rÉûå7ãÿÒÔòÏ0’Ñ¡À›l∆–i´%I'o®ÄT;ê$⁄∆®œ˝|ˇJŒÃO}fÆLÿSÅÇú≈eßµ¥SUë∑Úéû_0 \á”Ωnätπ{ôÍÉ‹ß#o4R‹u}C¬‹Tú€]Ò√Ñ6Éu£.‰Uh™f›¨—˛ØLDæ¶yú“êÆ0ÖK7øù»-˜ÏùLﬂ™ˆ∆ìÕ•DŒ[±ßsl"¡¢^ÄÕuÁ∆gÏ)5‘}gÕ &å∞IıˆQ%û¬J›¢kYÚñ	c5πÂ~÷£Du8r0?#Ë
 endstream
 endobj
-577 0 obj
+579 0 obj
 <<
 /Type /FontDescriptor
 /FontName /PGULSL+NimbusSanL-BoldItal
@@ -8553,10 +8563,10 @@ endobj
 /StemV 145
 /XHeight 532
 /CharSet (/A/C/G/I/L/S/T/W/X/Y/a/b/c/d/e/f/fi/four/g/h/hyphen/i/l/m/n/o/one/p/period/quotedblleft/quotedblright/r/s/t/three/two/u/x/y)
-/FontFile 576 0 R
+/FontFile 578 0 R
 >>
 endobj
-578 0 obj
+580 0 obj
 <<
 /Length1 1144
 /Length2 7770
@@ -8633,7 +8643,7 @@ sáátØtö”ÕL÷Ÿ^`?PÁˆÀ#êÆVÏ
 Ì=aÃΩ*`íëÊ€ˆdV	ßÁoIø¡N”À~DŸ')£Q‡¡‘òCv
 endstream
 endobj
-579 0 obj
+581 0 obj
 <<
 /Type /FontDescriptor
 /FontName /GCSHFS+NimbusSanL-Regu
@@ -8646,10 +8656,10 @@ endobj
 /StemV 85
 /XHeight 523
 /CharSet (/A/C/D/E/F/G/I/L/O/R/S/T/W/X/Y/a/at/b/backslash/braceleft/braceright/bracketleft/bracketright/c/colon/comma/d/e/eight/equal/f/five/g/h/i/k/l/m/n/o/one/p/percent/period/r/s/t/two/u/underscore/v/w/x/y/z/zero)
-/FontFile 578 0 R
+/FontFile 580 0 R
 >>
 endobj
-580 0 obj
+582 0 obj
 <<
 /Length1 1177
 /Length2 4468
@@ -8705,7 +8715,7 @@ N9cF˝‘∫ÇÂéãZ⁄©ôa)Mﬂ7Ê#B©“•Ã‚ˇËòi àT⁄~äºk"-~‚PùˆM^$ã®®—l!6ˆÅú0∑Yˇ
 ?ô!1ΩÌØn§–ö 7Ò0?VÚ≠ƒÉ¯Ï3}≤‰â∞œµäVãz"$¥mÆY“∂'©Ìpèe Cã®\¯√∑˜ågøLıM∂÷∏À°?ˇ‚¢qÃZ
 endstream
 endobj
-581 0 obj
+583 0 obj
 <<
 /Type /FontDescriptor
 /FontName /RFERHZ+NimbusSanL-ReguItal
@@ -8718,10 +8728,10 @@ endobj
 /StemV 88
 /XHeight 523
 /CharSet (/A/P/a/b/d/e/f/h/i/l/m/n/o/one/period/r/s/t/three/two/v/w/x)
-/FontFile 580 0 R
+/FontFile 582 0 R
 >>
 endobj
-582 0 obj
+584 0 obj
 <<
 /Length1 1626
 /Length2 12508
@@ -8810,7 +8820,7 @@ vÂÒøk3∫\<LÚmúÙ‡0ç≈ú&¢/≥†‘_8¶kÌ*@'£Ne∂]Òn Õ—Ùø_d˙¿∆≈j6~	ã
 ≥Á¶JA´6◊~•4¥i˘`°CR´ìTO´AVCZK≤Çó°™˛–b(≈Œ"„6ó√Ç±˚Ωÿ‹Ëî]e˙¶KháK\l?ó9«#¨ÖÚ∞â÷M=òsdølÉ>*Yyw\Á	ÌoÜ]WéX…¥?◊‹a’9£”l•ß„DÜÊêÍ®.@Bﬂc˙>√¡∫ˇ]„º GW˛s%ˆ-©ﬂ≠!/ÖòºÜËÛ,ÖívA2∏fpP±æ!U#ç]ú‰'» V:—1úLP‰«PMReÃ›R9n8?ﬁskæ±›QéNÔê£wß‚«“/´ä¯’J,‘ˇ’&Gö,Öãí#ªŸx¿€h∞⁄≥Ä0T–ëC˘Toﬂ0ÿ©ù}5°:=ƒ˙‡„NÔ¥2´B’Ç¨¨oO 8qÙP«™j¯∂··ÆAœ"çrngfÚGÁ≈◊ü;læ¶O˙rV ?¨á±˝Ü •Z€ΩÌú…Á°ìwÒƒØv|CjXÑíM^>{-Ã¥œbÆ$=‚*®ì±+±Ù…⁄ùdºn†öv-UÀ—FCºÉÌë„ü*øÁ}ª°>@U^sÔˇ<úHıΩ…gØßé`Ê~Éˇ„q
 endstream
 endobj
-583 0 obj
+585 0 obj
 <<
 /Type /FontDescriptor
 /FontName /QVXVAQ+NimbusRomNo9L-Medi
@@ -8823,10 +8833,10 @@ endobj
 /StemV 140
 /XHeight 461
 /CharSet (/A/C/D/I/P/R/T/U/a/b/c/colon/comma/d/e/eight/equal/f/fi/five/fl/four/g/h/hyphen/i/k/l/m/n/o/one/p/period/q/r/s/seven/six/t/three/two/u/v/w/y/zero)
-/FontFile 582 0 R
+/FontFile 584 0 R
 >>
 endobj
-584 0 obj
+586 0 obj
 <<
 /Length1 1642
 /Length2 8498
@@ -8918,7 +8928,7 @@ t,b ¶Ò¯R> •¿`7Ï€∂páøh÷LÎ}ÇV	⁄_∫+˙
 sKBà√¸ñ´ƒn÷·≈&‰˛€yÔñVV+≥T‹˚9WK$èdÆ ©(q“!!]∞S°µD(Ò]1/2DìVh5ﬁ“£ÇK3tcIÜP◊ùs±RˇD
 endstream
 endobj
-585 0 obj
+587 0 obj
 <<
 /Type /FontDescriptor
 /FontName /ZIYYUG+NimbusRomNo9L-MediItal
@@ -8931,10 +8941,10 @@ endobj
 /StemV 120
 /XHeight 462
 /CharSet (/a/b/c/d/e/f/fl/g/h/hyphen/i/l/m/n/o/p/r/s/t/two/x/y)
-/FontFile 584 0 R
+/FontFile 586 0 R
 >>
 endobj
-586 0 obj
+588 0 obj
 <<
 /Length1 1630
 /Length2 17065
@@ -9034,7 +9044,7 @@ Tªl[æ∫!RÈı¡.	g≠fp g„=≠m-∑©ìõ)Q‡^ú.~%¶'?Y}Hk>:‰NÆùIO.Ï/‚h…F~WÈÉ¿ß÷v°+E
 ¡∆êP…‘ë\9eß”~ûßvœ‡vö'´-M&jK»ﬁπU!œQ:Pöä¡∫–„õçÜ≥KÂ’08Nﬁ±ïRvmÄÁ{p¢V˚‘âv˛°∞8÷ùáπ\ Ê2Æ©8£g7ù¨#Usx&df≤ª]ÁJÂl´ö∏=+N-ÿZ¥ÉE∂Æ«K∂»µÎ‚ñrVjÉ≈Wÿπ6LØ<⁄q≥|Ê˙Î-2·'πh…–@ÈÛÈÇÜ[k_Ië\ÈáZQÓÆTŒ@rœ’4˛’fíu±éD,€hÑ€BzjÜ_„ Ω(u[√Àkò%ÔÊkCú<“ÅÃ†µ…øà9*“ZÍ¶Ï,eÖˇ9‹dNWfg!È¥ ∞I°˚U~z|XwÆü≥Ú®•gs∑z‘Ÿ¥◊öπ¶∂ìuπ¢˚Ø‚)ä†∆ZVø$©¢Ï˜0#c˚·&.ä1jÉøùPàîMÏ–Q•s,=Nv”o¨U≥d§	´X7è<«ÇßÌ.ﬂà˚&«∞d,<)Üt¸Uè-GŒ≠∆@XÕO`_™Ÿ; 9§∑
 endstream
 endobj
-587 0 obj
+589 0 obj
 <<
 /Type /FontDescriptor
 /FontName /XEECAZ+NimbusRomNo9L-Regu
@@ -9047,10 +9057,10 @@ endobj
 /StemV 85
 /XHeight 450
 /CharSet (/A/B/C/D/E/F/G/H/I/L/M/N/O/P/R/S/T/U/W/X/Y/a/b/bullet/c/colon/comma/d/e/eight/endash/f/fi/five/fl/four/g/h/hyphen/i/j/k/l/m/n/nine/o/one/p/parenleft/parenright/period/q/question/quotedblleft/quotedblright/quoteleft/quoteright/r/s/seven/six/slash/t/three/two/u/v/w/x/y/z/zero)
-/FontFile 586 0 R
+/FontFile 588 0 R
 >>
 endobj
-588 0 obj
+590 0 obj
 <<
 /Length1 1647
 /Length2 10178
@@ -9128,7 +9138,7 @@ v>^æ<ç˜¿´+ë%í1eÍìÄøü÷ñ⁄Nõ@Rl™ﬂ≥íxg‰7}"ìê@—÷›¿ﬁ–Gi¸XMä,1Ï°æêµrµ‚rY,bDMê:€\
 Öëï≥ªMw~#ƒ”uKA≠qX*‚h∏≠"ƒâldêjn©éÅÈˇÛL˝—†éFèq·o£Ã,Í—ï¬ÑÒ[/2Êô·‰?Ïmèm≈™l‰,yVˆMOZƒr`3féì¸°í‡xdñﬂËä,√æ«nøÄî÷„›ln:&àe˝»GzâNÿˆAœ‰ÅqÛ†wU1	8  Tä¯%"=ÊÖ?y∞‡å0õˇ©>:K‚ÖƒÛ¨öm
 endstream
 endobj
-589 0 obj
+591 0 obj
 <<
 /Type /FontDescriptor
 /FontName /LXNNMY+NimbusRomNo9L-ReguItal
@@ -9141,242 +9151,241 @@ endobj
 /StemV 78
 /XHeight 441
 /CharSet (/C/L/M/O/S/T/U/a/asterisk/b/c/d/e/f/g/h/hyphen/i/k/l/m/n/o/p/period/r/s/t/two/u/underscore/w/x/y)
-/FontFile 588 0 R
+/FontFile 590 0 R
 >>
 endobj
-550 0 obj
+552 0 obj
 <<
 /Type /Encoding
 /Differences [2/fi/fl 37/percent 39/quoteright/parenleft/parenright/asterisk/plus/comma/hyphen/period/slash/zero/one/two/three/four/five/six/seven/eight/nine/colon 61/equal 63/question/at/A/B/C/D/E/F/G/H/I 76/L/M/N/O/P 82/R/S/T/U 87/W/X/Y 91/bracketleft/backslash/bracketright/asciicircum/underscore/quoteleft/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/t/u/v/w/x/y/z/braceleft 125/braceright 147/quotedblleft/quotedblright/bullet/endash]
 >>
 endobj
-401 0 obj
+403 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /RFLZJB+CMR10
-/FontDescriptor 565 0 R
+/FontDescriptor 567 0 R
 /FirstChar 43
 /LastChar 61
-/Widths 554 0 R
->>
-endobj
-145 0 obj
-<<
-/Type /Font
-/Subtype /Type1
-/BaseFont /FRJGEQ+DummySpace
-/FontDescriptor 567 0 R
-/FirstChar 32
-/LastChar 32
-/Widths 561 0 R
->>
-endobj
-408 0 obj
-<<
-/Type /Font
-/Subtype /Type1
-/BaseFont /RXNEKG+MSAM10
-/FontDescriptor 569 0 R
-/FirstChar 88
-/LastChar 88
-/Widths 552 0 R
->>
-endobj
-402 0 obj
-<<
-/Type /Font
-/Subtype /Type1
-/BaseFont /LQLAWZ+NimbusMonL-Bold
-/FontDescriptor 571 0 R
-/FirstChar 50
-/LastChar 120
-/Widths 553 0 R
-/Encoding 550 0 R
->>
-endobj
-398 0 obj
-<<
-/Type /Font
-/Subtype /Type1
-/BaseFont /RVMJKN+NimbusMonL-Regu
-/FontDescriptor 573 0 R
-/FirstChar 43
-/LastChar 125
 /Widths 556 0 R
-/Encoding 550 0 R
->>
-endobj
-144 0 obj
-<<
-/Type /Font
-/Subtype /Type1
-/BaseFont /JHQXVN+NimbusSanL-Bold
-/FontDescriptor 575 0 R
-/FirstChar 2
-/LastChar 121
-/Widths 562 0 R
-/Encoding 550 0 R
->>
-endobj
-243 0 obj
-<<
-/Type /Font
-/Subtype /Type1
-/BaseFont /PGULSL+NimbusSanL-BoldItal
-/FontDescriptor 577 0 R
-/FirstChar 2
-/LastChar 148
-/Widths 557 0 R
-/Encoding 550 0 R
->>
-endobj
-451 0 obj
-<<
-/Type /Font
-/Subtype /Type1
-/BaseFont /GCSHFS+NimbusSanL-Regu
-/FontDescriptor 579 0 R
-/FirstChar 37
-/LastChar 125
-/Widths 551 0 R
-/Encoding 550 0 R
->>
-endobj
-399 0 obj
-<<
-/Type /Font
-/Subtype /Type1
-/BaseFont /RFERHZ+NimbusSanL-ReguItal
-/FontDescriptor 581 0 R
-/FirstChar 46
-/LastChar 120
-/Widths 555 0 R
-/Encoding 550 0 R
 >>
 endobj
 147 0 obj
 <<
 /Type /Font
 /Subtype /Type1
-/BaseFont /QVXVAQ+NimbusRomNo9L-Medi
-/FontDescriptor 583 0 R
-/FirstChar 2
-/LastChar 121
-/Widths 559 0 R
-/Encoding 550 0 R
->>
-endobj
-235 0 obj
-<<
-/Type /Font
-/Subtype /Type1
-/BaseFont /ZIYYUG+NimbusRomNo9L-MediItal
-/FontDescriptor 585 0 R
-/FirstChar 3
-/LastChar 121
-/Widths 558 0 R
-/Encoding 550 0 R
->>
-endobj
-141 0 obj
-<<
-/Type /Font
-/Subtype /Type1
-/BaseFont /XEECAZ+NimbusRomNo9L-Regu
-/FontDescriptor 587 0 R
-/FirstChar 2
-/LastChar 150
+/BaseFont /FRJGEQ+DummySpace
+/FontDescriptor 569 0 R
+/FirstChar 32
+/LastChar 32
 /Widths 563 0 R
-/Encoding 550 0 R
+>>
+endobj
+410 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /RXNEKG+MSAM10
+/FontDescriptor 571 0 R
+/FirstChar 88
+/LastChar 88
+/Widths 554 0 R
+>>
+endobj
+404 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /LQLAWZ+NimbusMonL-Bold
+/FontDescriptor 573 0 R
+/FirstChar 50
+/LastChar 120
+/Widths 555 0 R
+/Encoding 552 0 R
+>>
+endobj
+400 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /RVMJKN+NimbusMonL-Regu
+/FontDescriptor 575 0 R
+/FirstChar 43
+/LastChar 125
+/Widths 558 0 R
+/Encoding 552 0 R
 >>
 endobj
 146 0 obj
 <<
 /Type /Font
 /Subtype /Type1
-/BaseFont /LXNNMY+NimbusRomNo9L-ReguItal
-/FontDescriptor 589 0 R
-/FirstChar 42
+/BaseFont /JHQXVN+NimbusSanL-Bold
+/FontDescriptor 577 0 R
+/FirstChar 2
 /LastChar 121
-/Widths 560 0 R
-/Encoding 550 0 R
+/Widths 564 0 R
+/Encoding 552 0 R
 >>
 endobj
-152 0 obj
+245 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /PGULSL+NimbusSanL-BoldItal
+/FontDescriptor 579 0 R
+/FirstChar 2
+/LastChar 148
+/Widths 559 0 R
+/Encoding 552 0 R
+>>
+endobj
+453 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /GCSHFS+NimbusSanL-Regu
+/FontDescriptor 581 0 R
+/FirstChar 37
+/LastChar 125
+/Widths 553 0 R
+/Encoding 552 0 R
+>>
+endobj
+401 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /RFERHZ+NimbusSanL-ReguItal
+/FontDescriptor 583 0 R
+/FirstChar 46
+/LastChar 120
+/Widths 557 0 R
+/Encoding 552 0 R
+>>
+endobj
+149 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /QVXVAQ+NimbusRomNo9L-Medi
+/FontDescriptor 585 0 R
+/FirstChar 2
+/LastChar 121
+/Widths 561 0 R
+/Encoding 552 0 R
+>>
+endobj
+237 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /ZIYYUG+NimbusRomNo9L-MediItal
+/FontDescriptor 587 0 R
+/FirstChar 3
+/LastChar 121
+/Widths 560 0 R
+/Encoding 552 0 R
+>>
+endobj
+143 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /XEECAZ+NimbusRomNo9L-Regu
+/FontDescriptor 589 0 R
+/FirstChar 2
+/LastChar 150
+/Widths 565 0 R
+/Encoding 552 0 R
+>>
+endobj
+148 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /LXNNMY+NimbusRomNo9L-ReguItal
+/FontDescriptor 591 0 R
+/FirstChar 42
+/LastChar 121
+/Widths 562 0 R
+/Encoding 552 0 R
+>>
+endobj
+154 0 obj
 <<
 /Type /Pages
 /Count 6
-/Parent 590 0 R
-/Kids [61 0 R 155 0 R 245 0 R 405 0 R 409 0 R 456 0 R]
+/Parent 592 0 R
+/Kids [63 0 R 157 0 R 247 0 R 407 0 R 411 0 R 458 0 R]
 >>
 endobj
-548 0 obj
+550 0 obj
 <<
 /Type /Pages
 /Count 1
-/Parent 590 0 R
-/Kids [520 0 R]
+/Parent 592 0 R
+/Kids [522 0 R]
 >>
 endobj
-590 0 obj
+592 0 obj
 <<
 /Type /Pages
 /Count 7
-/Kids [152 0 R 548 0 R]
+/Kids [154 0 R 550 0 R]
 >>
 endobj
-591 0 obj
+593 0 obj
 <<
 /Type /Outlines
 /First 8 0 R
-/Last 44 0 R
-/Count 4
+/Last 60 0 R
+/Count 6
 >>
 endobj
-58 0 obj
+60 0 obj
 <<
-/Title 59 0 R
-/A 56 0 R
-/Parent 50 0 R
-/Prev 54 0 R
+/Title 61 0 R
+/A 58 0 R
+/Parent 593 0 R
+/Prev 56 0 R
 >>
 endobj
-54 0 obj
+56 0 obj
 <<
-/Title 55 0 R
-/A 52 0 R
-/Parent 50 0 R
-/Next 58 0 R
+/Title 57 0 R
+/A 54 0 R
+/Parent 593 0 R
+/Prev 44 0 R
+/Next 60 0 R
 >>
 endobj
-50 0 obj
+52 0 obj
 <<
-/Title 51 0 R
-/A 49 0 R
+/Title 53 0 R
+/A 50 0 R
 /Parent 44 0 R
-/Prev 47 0 R
-/First 54 0 R
-/Last 58 0 R
-/Count -2
+/Prev 48 0 R
 >>
 endobj
-47 0 obj
+48 0 obj
 <<
-/Title 48 0 R
+/Title 49 0 R
 /A 46 0 R
 /Parent 44 0 R
-/Next 50 0 R
+/Next 52 0 R
 >>
 endobj
 44 0 obj
 <<
 /Title 45 0 R
 /A 42 0 R
-/Parent 591 0 R
+/Parent 593 0 R
 /Prev 16 0 R
-/First 47 0 R
-/Last 50 0 R
+/Next 56 0 R
+/First 48 0 R
+/Last 52 0 R
 /Count -2
 >>
 endobj
@@ -9437,7 +9446,7 @@ endobj
 <<
 /Title 17 0 R
 /A 14 0 R
-/Parent 591 0 R
+/Parent 593 0 R
 /Prev 12 0 R
 /Next 44 0 R
 /First 20 0 R
@@ -9449,7 +9458,7 @@ endobj
 <<
 /Title 13 0 R
 /A 10 0 R
-/Parent 591 0 R
+/Parent 593 0 R
 /Prev 8 0 R
 /Next 16 0 R
 >>
@@ -9458,713 +9467,715 @@ endobj
 <<
 /Title 9 0 R
 /A 6 0 R
-/Parent 591 0 R
+/Parent 593 0 R
 /Next 12 0 R
->>
-endobj
-592 0 obj
-<<
-/Names [(Doc-Start) 142 0 R (Item.1) 234 0 R (Item.10) 513 0 R (Item.2) 236 0 R (Item.3) 237 0 R (Item.4) 238 0 R]
-/Limits [(Doc-Start) (Item.4)]
->>
-endobj
-593 0 obj
-<<
-/Names [(Item.5) 239 0 R (Item.6) 240 0 R (Item.7) 241 0 R (Item.8) 242 0 R (Item.9) 512 0 R (equation.0.3.1) 400 0 R]
-/Limits [(Item.5) (equation.0.3.1)]
 >>
 endobj
 594 0 obj
 <<
-/Names [(equation.0.3.2) 403 0 R (figure.caption.3) 153 0 R (lstlisting.-1) 449 0 R (lstlisting.-2) 454 0 R (lstlisting.-3) 514 0 R (lstlisting.-4) 516 0 R]
-/Limits [(equation.0.3.2) (lstlisting.-4)]
+/Names [(Doc-Start) 144 0 R (Item.1) 236 0 R (Item.10) 515 0 R (Item.2) 238 0 R (Item.3) 239 0 R (Item.4) 240 0 R]
+/Limits [(Doc-Start) (Item.4)]
 >>
 endobj
 595 0 obj
 <<
-/Names [(lstlisting.-5) 518 0 R (lstnumber.-1.2) 450 0 R (lstnumber.-2.2) 455 0 R (lstnumber.-3.2) 515 0 R (lstnumber.-4.2) 517 0 R (lstnumber.-5.2) 519 0 R]
-/Limits [(lstlisting.-5) (lstnumber.-5.2)]
+/Names [(Item.5) 241 0 R (Item.6) 242 0 R (Item.7) 243 0 R (Item.8) 244 0 R (Item.9) 514 0 R (equation.0.3.1) 402 0 R]
+/Limits [(Item.5) (equation.0.3.1)]
 >>
 endobj
 596 0 obj
 <<
-/Names [(page.1) 140 0 R (page.2) 233 0 R (page.3) 397 0 R (page.4) 407 0 R (page.5) 448 0 R (page.6) 509 0 R]
-/Limits [(page.1) (page.6)]
+/Names [(equation.0.3.2) 405 0 R (figure.caption.3) 155 0 R (lstlisting.-1) 451 0 R (lstlisting.-2) 456 0 R (lstlisting.-3) 516 0 R (lstlisting.-4) 518 0 R]
+/Limits [(equation.0.3.2) (lstlisting.-4)]
 >>
 endobj
 597 0 obj
 <<
-/Names [(page.7) 542 0 R (section*.1) 143 0 R (section*.4) 547 0 R (section.0.1) 7 0 R (section.0.2) 11 0 R (section.0.3) 15 0 R]
-/Limits [(page.7) (section.0.3)]
+/Names [(lstlisting.-5) 520 0 R (lstnumber.-1.2) 452 0 R (lstnumber.-2.2) 457 0 R (lstnumber.-3.2) 517 0 R (lstnumber.-4.2) 519 0 R (lstnumber.-5.2) 521 0 R]
+/Limits [(lstlisting.-5) (lstnumber.-5.2)]
 >>
 endobj
 598 0 obj
 <<
-/Names [(section.0.4) 43 0 R (section.0.5) 53 0 R (section.0.6) 57 0 R (subsection.0.1) 19 0 R (subsection.0.2) 23 0 R (subsection.0.3) 35 0 R]
-/Limits [(section.0.4) (subsection.0.3)]
+/Names [(page.1) 142 0 R (page.2) 235 0 R (page.3) 399 0 R (page.4) 409 0 R (page.5) 450 0 R (page.6) 511 0 R]
+/Limits [(page.1) (page.6)]
 >>
 endobj
 599 0 obj
 <<
-/Names [(subsection.0.4) 39 0 R (subsubsection.0.3.1) 27 0 R (subsubsection.0.3.2) 31 0 R (table.caption.2) 154 0 R]
-/Limits [(subsection.0.4) (table.caption.2)]
+/Names [(page.7) 544 0 R (section*.1) 145 0 R (section*.4) 549 0 R (section.0.1) 7 0 R (section.0.2) 11 0 R (section.0.3) 15 0 R]
+/Limits [(page.7) (section.0.3)]
 >>
 endobj
 600 0 obj
 <<
-/Kids [592 0 R 593 0 R 594 0 R 595 0 R 596 0 R 597 0 R]
-/Limits [(Doc-Start) (section.0.3)]
+/Names [(section.0.4) 43 0 R (section.0.5) 55 0 R (section.0.6) 59 0 R (subsection.0.3.1) 19 0 R (subsection.0.3.2) 23 0 R (subsection.0.3.3) 35 0 R]
+/Limits [(section.0.4) (subsection.0.3.3)]
 >>
 endobj
 601 0 obj
 <<
-/Kids [598 0 R 599 0 R]
-/Limits [(section.0.4) (table.caption.2)]
+/Names [(subsection.0.3.4) 39 0 R (subsection.0.4.1) 47 0 R (subsection.0.4.2) 51 0 R (subsubsection.0.3.2.1) 27 0 R (subsubsection.0.3.2.2) 31 0 R (table.caption.2) 156 0 R]
+/Limits [(subsection.0.3.4) (table.caption.2)]
 >>
 endobj
 602 0 obj
 <<
-/Kids [600 0 R 601 0 R]
-/Limits [(Doc-Start) (table.caption.2)]
+/Kids [594 0 R 595 0 R 596 0 R 597 0 R 598 0 R 599 0 R]
+/Limits [(Doc-Start) (section.0.3)]
 >>
 endobj
 603 0 obj
 <<
-/Dests 602 0 R
+/Kids [600 0 R 601 0 R]
+/Limits [(section.0.4) (table.caption.2)]
 >>
 endobj
 604 0 obj
 <<
-/Type /Catalog
-/Pages 590 0 R
-/Outlines 591 0 R
-/Names 603 0 R
-/PageMode/UseOutlines/Lang(EN)/StructTreeRoot 4 0 R/MarkInfo <</Marked true /LetterspaceFlags 0>>
-/OpenAction 60 0 R
+/Kids [602 0 R 603 0 R]
+/Limits [(Doc-Start) (table.caption.2)]
 >>
 endobj
 605 0 obj
 <<
+/Dests 604 0 R
+>>
+endobj
+606 0 obj
+<<
+/Type /Catalog
+/Pages 592 0 R
+/Outlines 593 0 R
+/Names 605 0 R
+/PageMode/UseOutlines/Lang(EN)/StructTreeRoot 4 0 R/MarkInfo <</Marked true /LetterspaceFlags 0>>
+/OpenAction 62 0 R
+>>
+endobj
+607 0 obj
+<<
 /Author(\376\377\000A\000n\000d\000y\000\040\000C\000l\000i\000f\000t\000o\000n)/Title(\376\377\000S\000o\000\040\000y\000o\000u\000\040\000w\000a\000n\000t\000\040\000t\000o\000\040\000r\000e\000p\000l\000a\000c\000e\000\040\000y\000o\000u\000r\000\040\000W\000Y\000S\000I\000W\000Y\000G\000\040\000w\000o\000r\000d\000\040\000p\000r\000o\000c\000e\000s\000s\000o\000r\000\040\000w\000i\000t\000h\000\040\000L\000a\000T\000e\000X\000,\000\040\000b\000u\000t\000\040\0005\0000\0008\000\040\000c\000o\000m\000p\000l\000i\000a\000n\000c\000e\000\040\000h\000a\000s\000\040\000y\000o\000u\000\040\000s\000t\000u\000m\000p\000e\000d\000?)/Subject()/Creator(LaTeX with hyperref package)/Producer(pdfTeX-1.40.17)/Keywords()
-/CreationDate (D:20170317120236-06'00')
-/ModDate (D:20170317120236-06'00')
+/CreationDate (D:20170318132454+01'00')
+/ModDate (D:20170318132454+01'00')
 /Trapped /False
 /PTEX.Fullbanner (This is pdfTeX, Version 3.14159265-2.6-1.40.17 (TeX Live 2016) kpathsea version 6.2.2)
 >>
 endobj
 xref
-0 606
-0000000344 65535 f 
-0000450779 00000 n 
-0000450799 00000 n 
-0000450819 00000 n 
-0000450632 00000 n 
+0 608
+0000000346 65535 f 
+0000451057 00000 n 
+0000451077 00000 n 
+0000451097 00000 n 
+0000450910 00000 n 
 0000000015 00000 n 
 0000002011 00000 n 
-0000064882 00000 n 
-0000607920 00000 n 
+0000065040 00000 n 
+0000608189 00000 n 
 0000002058 00000 n 
 0000002144 00000 n 
-0000118961 00000 n 
-0000607833 00000 n 
+0000119119 00000 n 
+0000608102 00000 n 
 0000002192 00000 n 
 0000002279 00000 n 
-0000119017 00000 n 
-0000607708 00000 n 
+0000119175 00000 n 
+0000607977 00000 n 
 0000002327 00000 n 
 0000002602 00000 n 
-0000119570 00000 n 
-0000607634 00000 n 
-0000002653 00000 n 
-0000002827 00000 n 
-0000187224 00000 n 
-0000607510 00000 n 
-0000002878 00000 n 
-0000003013 00000 n 
-0000187281 00000 n 
-0000607436 00000 n 
-0000003069 00000 n 
-0000003179 00000 n 
-0000187466 00000 n 
-0000607362 00000 n 
-0000003235 00000 n 
-0000003411 00000 n 
-0000389075 00000 n 
-0000607275 00000 n 
-0000003462 00000 n 
-0000003542 00000 n 
-0000389131 00000 n 
-0000607201 00000 n 
-0000003593 00000 n 
-0000003903 00000 n 
-0000446044 00000 n 
-0000607089 00000 n 
-0000003951 00000 n 
-0000004099 00000 n 
-0000607015 00000 n 
-0000004150 00000 n 
-0000004298 00000 n 
-0000606904 00000 n 
-0000004349 00000 n 
-0000004472 00000 n 
-0000463834 00000 n 
-0000606830 00000 n 
-0000004520 00000 n 
-0000004691 00000 n 
-0000463890 00000 n 
-0000606756 00000 n 
-0000004739 00000 n 
-0000004821 00000 n 
-0000058574 00000 n 
-0000450113 00000 n 
-0000014002 00000 n 
-0000004869 00000 n 
-0000013921 00000 n 
-0000013840 00000 n 
-0000013762 00000 n 
-0000013654 00000 n 
-0000004974 00000 n 
-0000006240 00000 n 
-0000008165 00000 n 
-0000010594 00000 n 
-0000014102 00000 n 
-0000017138 00000 n 
-0000014207 00000 n 
-0000014530 00000 n 
-0000014314 00000 n 
-0000014422 00000 n 
-0000014719 00000 n 
-0000016357 00000 n 
-0000014824 00000 n 
-0000058973 00000 n 
-0000059129 00000 n 
-0000014933 00000 n 
-0000059286 00000 n 
-0000059441 00000 n 
-0000015042 00000 n 
-0000059597 00000 n 
-0000059753 00000 n 
-0000015151 00000 n 
-0000059910 00000 n 
-0000060069 00000 n 
-0000015260 00000 n 
-0000060229 00000 n 
-0000060387 00000 n 
-0000015369 00000 n 
-0000060547 00000 n 
-0000060712 00000 n 
-0000015478 00000 n 
-0000060877 00000 n 
-0000061043 00000 n 
-0000015587 00000 n 
-0000061209 00000 n 
-0000061369 00000 n 
-0000015697 00000 n 
-0000061529 00000 n 
-0000062003 00000 n 
-0000015807 00000 n 
-0000062164 00000 n 
-0000062320 00000 n 
-0000015917 00000 n 
-0000062478 00000 n 
-0000062638 00000 n 
-0000016027 00000 n 
-0000062799 00000 n 
-0000062958 00000 n 
-0000016137 00000 n 
-0000063118 00000 n 
-0000063272 00000 n 
-0000016247 00000 n 
-0000063427 00000 n 
+0000119728 00000 n 
+0000607903 00000 n 
+0000002655 00000 n 
+0000002829 00000 n 
+0000187382 00000 n 
+0000607779 00000 n 
+0000002882 00000 n 
+0000003017 00000 n 
+0000187439 00000 n 
+0000607705 00000 n 
+0000003075 00000 n 
+0000003185 00000 n 
+0000187624 00000 n 
+0000607631 00000 n 
+0000003243 00000 n 
+0000003419 00000 n 
+0000389235 00000 n 
+0000607544 00000 n 
+0000003472 00000 n 
+0000003552 00000 n 
+0000389291 00000 n 
+0000607470 00000 n 
+0000003605 00000 n 
+0000003915 00000 n 
+0000446204 00000 n 
+0000607345 00000 n 
+0000003963 00000 n 
+0000004111 00000 n 
+0000446487 00000 n 
+0000607271 00000 n 
+0000004164 00000 n 
+0000004312 00000 n 
+0000446668 00000 n 
+0000607197 00000 n 
+0000004365 00000 n 
+0000004488 00000 n 
+0000464112 00000 n 
+0000607109 00000 n 
+0000004536 00000 n 
+0000004707 00000 n 
+0000464168 00000 n 
+0000607034 00000 n 
+0000004755 00000 n 
+0000004837 00000 n 
+0000058689 00000 n 
+0000450391 00000 n 
+0000014018 00000 n 
+0000004885 00000 n 
+0000013937 00000 n 
+0000013856 00000 n 
+0000013778 00000 n 
+0000013670 00000 n 
+0000004990 00000 n 
+0000006256 00000 n 
+0000008181 00000 n 
+0000010610 00000 n 
+0000014118 00000 n 
+0000017156 00000 n 
+0000014223 00000 n 
+0000014546 00000 n 
+0000014330 00000 n 
+0000014438 00000 n 
+0000014735 00000 n 
+0000016374 00000 n 
+0000014840 00000 n 
+0000059089 00000 n 
+0000059245 00000 n 
+0000014949 00000 n 
+0000059402 00000 n 
+0000059558 00000 n 
+0000015058 00000 n 
+0000059715 00000 n 
+0000059871 00000 n 
+0000015167 00000 n 
+0000060028 00000 n 
+0000060189 00000 n 
+0000015276 00000 n 
+0000060351 00000 n 
+0000060512 00000 n 
+0000015385 00000 n 
+0000060674 00000 n 
+0000060841 00000 n 
+0000015494 00000 n 
+0000061009 00000 n 
+0000061177 00000 n 
+0000015604 00000 n 
+0000061345 00000 n 
+0000061507 00000 n 
+0000015714 00000 n 
+0000061670 00000 n 
+0000062154 00000 n 
+0000015824 00000 n 
+0000062317 00000 n 
+0000062472 00000 n 
+0000015934 00000 n 
+0000062629 00000 n 
+0000062791 00000 n 
+0000016044 00000 n 
+0000062954 00000 n 
+0000063115 00000 n 
+0000016154 00000 n 
+0000063276 00000 n 
+0000063430 00000 n 
+0000016264 00000 n 
 0000063585 00000 n 
-0000016536 00000 n 
-0000016754 00000 n 
-0000016643 00000 n 
 0000063743 00000 n 
-0000063905 00000 n 
-0000016837 00000 n 
-0000017055 00000 n 
-0000016944 00000 n 
-0000064067 00000 n 
-0000064553 00000 n 
-0000067849 00000 n 
-0000017287 00000 n 
-0000017397 00000 n 
-0000065117 00000 n 
-0000017505 00000 n 
-0000064941 00000 n 
-0000017616 00000 n 
-0000064715 00000 n 
-0000606069 00000 n 
-0000064771 00000 n 
-0000064827 00000 n 
-0000605029 00000 n 
-0000604397 00000 n 
-0000606242 00000 n 
-0000605719 00000 n 
-0000061688 00000 n 
-0000061844 00000 n 
-0000064229 00000 n 
-0000064391 00000 n 
-0000606420 00000 n 
-0000388904 00000 n 
-0000209242 00000 n 
-0000118610 00000 n 
-0000066890 00000 n 
-0000065533 00000 n 
-0000065305 00000 n 
-0000065418 00000 n 
-0000065850 00000 n 
-0000065622 00000 n 
-0000065735 00000 n 
-0000066167 00000 n 
-0000065939 00000 n 
-0000066052 00000 n 
-0000066484 00000 n 
-0000066256 00000 n 
-0000066369 00000 n 
-0000066801 00000 n 
-0000066573 00000 n 
-0000066686 00000 n 
-0000067227 00000 n 
-0000067003 00000 n 
-0000067115 00000 n 
-0000067650 00000 n 
-0000067426 00000 n 
-0000067538 00000 n 
-0000069259 00000 n 
-0000067991 00000 n 
-0000068102 00000 n 
-0000069162 00000 n 
-0000068439 00000 n 
-0000068211 00000 n 
-0000068324 00000 n 
-0000068756 00000 n 
-0000068528 00000 n 
-0000068641 00000 n 
-0000069073 00000 n 
-0000068845 00000 n 
-0000068958 00000 n 
-0000392439 00000 n 
-0000069377 00000 n 
-0000069488 00000 n 
-0000072447 00000 n 
-0000069982 00000 n 
-0000069597 00000 n 
-0000069822 00000 n 
-0000069710 00000 n 
-0000070456 00000 n 
-0000070071 00000 n 
-0000070296 00000 n 
-0000070184 00000 n 
-0000070773 00000 n 
-0000070545 00000 n 
-0000070658 00000 n 
-0000071090 00000 n 
-0000070862 00000 n 
-0000070975 00000 n 
-0000071407 00000 n 
-0000071179 00000 n 
-0000071292 00000 n 
-0000071724 00000 n 
-0000071496 00000 n 
-0000071609 00000 n 
-0000072041 00000 n 
-0000071813 00000 n 
-0000071926 00000 n 
-0000072358 00000 n 
-0000072130 00000 n 
-0000072243 00000 n 
-0000072584 00000 n 
-0000072693 00000 n 
-0000136017 00000 n 
-0000072802 00000 n 
-0000073160 00000 n 
-0000072913 00000 n 
-0000073025 00000 n 
-0000118742 00000 n 
-0000119820 00000 n 
-0000073360 00000 n 
-0000119631 00000 n 
-0000073472 00000 n 
-0000118904 00000 n 
-0000119074 00000 n 
-0000605892 00000 n 
-0000119136 00000 n 
-0000119198 00000 n 
-0000119260 00000 n 
-0000119322 00000 n 
-0000119384 00000 n 
-0000119446 00000 n 
-0000119508 00000 n 
-0000605199 00000 n 
-0000120198 00000 n 
-0000186456 00000 n 
-0000119974 00000 n 
-0000120086 00000 n 
-0000120397 00000 n 
-0000123376 00000 n 
-0000120896 00000 n 
-0000120507 00000 n 
-0000120734 00000 n 
-0000120621 00000 n 
-0000121374 00000 n 
-0000120985 00000 n 
-0000121212 00000 n 
-0000121099 00000 n 
-0000121852 00000 n 
-0000121463 00000 n 
-0000121690 00000 n 
-0000121577 00000 n 
-0000122330 00000 n 
-0000121941 00000 n 
-0000122168 00000 n 
-0000122055 00000 n 
-0000122649 00000 n 
-0000122419 00000 n 
-0000122533 00000 n 
-0000122968 00000 n 
-0000122738 00000 n 
-0000122852 00000 n 
-0000123287 00000 n 
-0000123057 00000 n 
-0000123171 00000 n 
-0000123754 00000 n 
-0000123505 00000 n 
-0000186843 00000 n 
-0000123641 00000 n 
-0000124183 00000 n 
-0000123957 00000 n 
-0000124070 00000 n 
-0000124393 00000 n 
-0000124503 00000 n 
-0000124613 00000 n 
-0000124723 00000 n 
-0000124833 00000 n 
-0000124943 00000 n 
-0000125318 00000 n 
-0000125053 00000 n 
-0000125702 00000 n 
-0000125399 00000 n 
-0000126086 00000 n 
-0000125783 00000 n 
-0000126470 00000 n 
-0000126167 00000 n 
-0000126854 00000 n 
-0000126551 00000 n 
-0000127238 00000 n 
-0000126935 00000 n 
-0000127622 00000 n 
-0000127319 00000 n 
-0000128348 00000 n 
-0000127952 00000 n 
-0000127703 00000 n 
-0000127816 00000 n 
-0000209020 00000 n 
-0000129209 00000 n 
-0000128768 00000 n 
-0000128429 00000 n 
-0000128542 00000 n 
-0000128655 00000 n 
-0000129593 00000 n 
-0000129290 00000 n 
-0000129977 00000 n 
-0000129674 00000 n 
-0000130361 00000 n 
-0000130058 00000 n 
-0000130745 00000 n 
-0000130442 00000 n 
-0000131129 00000 n 
-0000130826 00000 n 
-0000131513 00000 n 
-0000131210 00000 n 
-0000131897 00000 n 
-0000131594 00000 n 
-0000132281 00000 n 
-0000131978 00000 n 
-0000132665 00000 n 
-0000132362 00000 n 
-0000133087 00000 n 
-0000132746 00000 n 
-0000133433 00000 n 
-0000133168 00000 n 
-0000133817 00000 n 
-0000133514 00000 n 
-0000134201 00000 n 
-0000133898 00000 n 
-0000134782 00000 n 
-0000134395 00000 n 
-0000134282 00000 n 
-0000135128 00000 n 
-0000134863 00000 n 
-0000135936 00000 n 
-0000000549 00000 f 
-0000135847 00000 n 
-0000135439 00000 n 
-0000135209 00000 n 
-0000135323 00000 n 
-0000135758 00000 n 
-0000135528 00000 n 
-0000135642 00000 n 
-0000210541 00000 n 
-0000136442 00000 n 
-0000136704 00000 n 
-0000136591 00000 n 
-0000140372 00000 n 
-0000136860 00000 n 
-0000136972 00000 n 
-0000137082 00000 n 
-0000186604 00000 n 
-0000137388 00000 n 
-0000137162 00000 n 
-0000137275 00000 n 
-0000137726 00000 n 
-0000137590 00000 n 
-0000187004 00000 n 
-0000137883 00000 n 
-0000137993 00000 n 
-0000138103 00000 n 
-0000244204 00000 n 
-0000138220 00000 n 
-0000138337 00000 n 
-0000387245 00000 n 
-0000138454 00000 n 
-0000138571 00000 n 
-0000138681 00000 n 
-0000138791 00000 n 
-0000138901 00000 n 
-0000139018 00000 n 
-0000139135 00000 n 
-0000387619 00000 n 
-0000139252 00000 n 
-0000139369 00000 n 
-0000139479 00000 n 
-0000139589 00000 n 
-0000139707 00000 n 
-0000140043 00000 n 
-0000139817 00000 n 
-0000139930 00000 n 
-0000140245 00000 n 
-0000210392 00000 n 
-0000140669 00000 n 
-0000209542 00000 n 
-0000140781 00000 n 
-0000187527 00000 n 
-0000140894 00000 n 
-0000187167 00000 n 
-0000604858 00000 n 
-0000605544 00000 n 
-0000187342 00000 n 
-0000604255 00000 n 
-0000604687 00000 n 
-0000187404 00000 n 
-0000209299 00000 n 
-0000208888 00000 n 
-0000187770 00000 n 
-0000209185 00000 n 
-0000604544 00000 n 
-0000244032 00000 n 
-0000209961 00000 n 
-0000209735 00000 n 
-0000209848 00000 n 
-0000210163 00000 n 
-0000211085 00000 n 
-0000210680 00000 n 
-0000210928 00000 n 
-0000210792 00000 n 
-0000388095 00000 n 
-0000392236 00000 n 
-0000211197 00000 n 
-0000211671 00000 n 
-0000211309 00000 n 
-0000211422 00000 n 
-0000211535 00000 n 
-0000388296 00000 n 
-0000212861 00000 n 
-0000211957 00000 n 
-0000212070 00000 n 
-0000212183 00000 n 
-0000212296 00000 n 
-0000212409 00000 n 
-0000212522 00000 n 
-0000212635 00000 n 
-0000212748 00000 n 
-0000213339 00000 n 
-0000213449 00000 n 
-0000213753 00000 n 
-0000213640 00000 n 
-0000214022 00000 n 
-0000213909 00000 n 
-0000392131 00000 n 
-0000389789 00000 n 
-0000214178 00000 n 
-0000389590 00000 n 
-0000214292 00000 n 
-0000389310 00000 n 
-0000214405 00000 n 
-0000388847 00000 n 
-0000388961 00000 n 
-0000389018 00000 n 
-0000605373 00000 n 
-0000388480 00000 n 
-0000388663 00000 n 
-0000389187 00000 n 
-0000389249 00000 n 
-0000445250 00000 n 
-0000390585 00000 n 
-0000389878 00000 n 
-0000390331 00000 n 
-0000389992 00000 n 
-0000390105 00000 n 
-0000390218 00000 n 
-0000391723 00000 n 
-0000390674 00000 n 
-0000391376 00000 n 
-0000390788 00000 n 
-0000390901 00000 n 
-0000445398 00000 n 
-0000391037 00000 n 
-0000391150 00000 n 
-0000391263 00000 n 
-0000392042 00000 n 
-0000391812 00000 n 
-0000391926 00000 n 
-0000447928 00000 n 
-0000392639 00000 n 
-0000392751 00000 n 
-0000393817 00000 n 
-0000393250 00000 n 
-0000392861 00000 n 
-0000393088 00000 n 
-0000392975 00000 n 
-0000393728 00000 n 
-0000393339 00000 n 
-0000393566 00000 n 
-0000393453 00000 n 
-0000393906 00000 n 
-0000394242 00000 n 
-0000394016 00000 n 
-0000394129 00000 n 
-0000394444 00000 n 
-0000396726 00000 n 
-0000394825 00000 n 
-0000395539 00000 n 
-0000394974 00000 n 
-0000395087 00000 n 
-0000395200 00000 n 
-0000395313 00000 n 
-0000395426 00000 n 
-0000396105 00000 n 
-0000395879 00000 n 
-0000395992 00000 n 
-0000396307 00000 n 
-0000447808 00000 n 
-0000396867 00000 n 
-0000446819 00000 n 
-0000446575 00000 n 
-0000396979 00000 n 
-0000445987 00000 n 
-0000445595 00000 n 
-0000445791 00000 n 
-0000446100 00000 n 
-0000446156 00000 n 
-0000446213 00000 n 
-0000446270 00000 n 
-0000446327 00000 n 
-0000446389 00000 n 
-0000446451 00000 n 
-0000446513 00000 n 
-0000462113 00000 n 
-0000448502 00000 n 
-0000448097 00000 n 
-0000448345 00000 n 
-0000448209 00000 n 
-0000462558 00000 n 
-0000449485 00000 n 
-0000448627 00000 n 
-0000449191 00000 n 
-0000448739 00000 n 
-0000448852 00000 n 
-0000448965 00000 n 
-0000449078 00000 n 
-0000449999 00000 n 
-0000449594 00000 n 
-0000449842 00000 n 
-0000449706 00000 n 
-0000463597 00000 n 
-0000450266 00000 n 
-0000462285 00000 n 
-0000464003 00000 n 
-0000450872 00000 n 
-0000463777 00000 n 
-0000462767 00000 n 
-0000462974 00000 n 
-0000463182 00000 n 
-0000463389 00000 n 
-0000463946 00000 n 
-0000606536 00000 n 
+0000016554 00000 n 
+0000016772 00000 n 
+0000016661 00000 n 
+0000063901 00000 n 
+0000064064 00000 n 
+0000016855 00000 n 
+0000017073 00000 n 
+0000016962 00000 n 
+0000064226 00000 n 
+0000064711 00000 n 
+0000068007 00000 n 
+0000017305 00000 n 
+0000017415 00000 n 
+0000065275 00000 n 
+0000017523 00000 n 
+0000065099 00000 n 
+0000017634 00000 n 
+0000064872 00000 n 
+0000606347 00000 n 
+0000064928 00000 n 
+0000064984 00000 n 
+0000605307 00000 n 
+0000604675 00000 n 
+0000606520 00000 n 
+0000605997 00000 n 
+0000061832 00000 n 
+0000061993 00000 n 
+0000064388 00000 n 
+0000064550 00000 n 
+0000606698 00000 n 
+0000389064 00000 n 
+0000209402 00000 n 
+0000118768 00000 n 
+0000067048 00000 n 
+0000065691 00000 n 
+0000065463 00000 n 
+0000065576 00000 n 
+0000066008 00000 n 
+0000065780 00000 n 
+0000065893 00000 n 
+0000066325 00000 n 
+0000066097 00000 n 
+0000066210 00000 n 
+0000066642 00000 n 
+0000066414 00000 n 
+0000066527 00000 n 
+0000066959 00000 n 
+0000066731 00000 n 
+0000066844 00000 n 
+0000067385 00000 n 
+0000067161 00000 n 
+0000067273 00000 n 
+0000067808 00000 n 
+0000067584 00000 n 
+0000067696 00000 n 
+0000069417 00000 n 
+0000068149 00000 n 
+0000068260 00000 n 
+0000069320 00000 n 
+0000068597 00000 n 
+0000068369 00000 n 
+0000068482 00000 n 
+0000068914 00000 n 
+0000068686 00000 n 
+0000068799 00000 n 
+0000069231 00000 n 
+0000069003 00000 n 
+0000069116 00000 n 
+0000392599 00000 n 
+0000069535 00000 n 
+0000069646 00000 n 
+0000072605 00000 n 
+0000070140 00000 n 
+0000069755 00000 n 
+0000069980 00000 n 
+0000069868 00000 n 
+0000070614 00000 n 
+0000070229 00000 n 
+0000070454 00000 n 
+0000070342 00000 n 
+0000070931 00000 n 
+0000070703 00000 n 
+0000070816 00000 n 
+0000071248 00000 n 
+0000071020 00000 n 
+0000071133 00000 n 
+0000071565 00000 n 
+0000071337 00000 n 
+0000071450 00000 n 
+0000071882 00000 n 
+0000071654 00000 n 
+0000071767 00000 n 
+0000072199 00000 n 
+0000071971 00000 n 
+0000072084 00000 n 
+0000072516 00000 n 
+0000072288 00000 n 
+0000072401 00000 n 
+0000072742 00000 n 
+0000072851 00000 n 
+0000136175 00000 n 
+0000072960 00000 n 
+0000073318 00000 n 
+0000073071 00000 n 
+0000073183 00000 n 
+0000118900 00000 n 
+0000119978 00000 n 
+0000073518 00000 n 
+0000119789 00000 n 
+0000073630 00000 n 
+0000119062 00000 n 
+0000119232 00000 n 
+0000606170 00000 n 
+0000119294 00000 n 
+0000119356 00000 n 
+0000119418 00000 n 
+0000119480 00000 n 
+0000119542 00000 n 
+0000119604 00000 n 
+0000119666 00000 n 
+0000605477 00000 n 
+0000120356 00000 n 
+0000186614 00000 n 
+0000120132 00000 n 
+0000120244 00000 n 
+0000120555 00000 n 
+0000123534 00000 n 
+0000121054 00000 n 
+0000120665 00000 n 
+0000120892 00000 n 
+0000120779 00000 n 
+0000121532 00000 n 
+0000121143 00000 n 
+0000121370 00000 n 
+0000121257 00000 n 
+0000122010 00000 n 
+0000121621 00000 n 
+0000121848 00000 n 
+0000121735 00000 n 
+0000122488 00000 n 
+0000122099 00000 n 
+0000122326 00000 n 
+0000122213 00000 n 
+0000122807 00000 n 
+0000122577 00000 n 
+0000122691 00000 n 
+0000123126 00000 n 
+0000122896 00000 n 
+0000123010 00000 n 
+0000123445 00000 n 
+0000123215 00000 n 
+0000123329 00000 n 
+0000123912 00000 n 
+0000123663 00000 n 
+0000187001 00000 n 
+0000123799 00000 n 
+0000124341 00000 n 
+0000124115 00000 n 
+0000124228 00000 n 
+0000124551 00000 n 
+0000124661 00000 n 
+0000124771 00000 n 
+0000124881 00000 n 
+0000124991 00000 n 
+0000125101 00000 n 
+0000125476 00000 n 
+0000125211 00000 n 
+0000125860 00000 n 
+0000125557 00000 n 
+0000126244 00000 n 
+0000125941 00000 n 
+0000126628 00000 n 
+0000126325 00000 n 
+0000127012 00000 n 
+0000126709 00000 n 
+0000127396 00000 n 
+0000127093 00000 n 
+0000127780 00000 n 
+0000127477 00000 n 
+0000128506 00000 n 
+0000128110 00000 n 
+0000127861 00000 n 
+0000127974 00000 n 
+0000209178 00000 n 
+0000129367 00000 n 
+0000128926 00000 n 
+0000128587 00000 n 
+0000128700 00000 n 
+0000128813 00000 n 
+0000129751 00000 n 
+0000129448 00000 n 
+0000130135 00000 n 
+0000129832 00000 n 
+0000130519 00000 n 
+0000130216 00000 n 
+0000130903 00000 n 
+0000130600 00000 n 
+0000131287 00000 n 
+0000130984 00000 n 
+0000131671 00000 n 
+0000131368 00000 n 
+0000132055 00000 n 
+0000131752 00000 n 
+0000132439 00000 n 
+0000132136 00000 n 
+0000132823 00000 n 
+0000132520 00000 n 
+0000133245 00000 n 
+0000132904 00000 n 
+0000133591 00000 n 
+0000133326 00000 n 
+0000133975 00000 n 
+0000133672 00000 n 
+0000134359 00000 n 
+0000134056 00000 n 
+0000134940 00000 n 
+0000134553 00000 n 
+0000134440 00000 n 
+0000135286 00000 n 
+0000135021 00000 n 
+0000136094 00000 n 
+0000000551 00000 f 
+0000136005 00000 n 
+0000135597 00000 n 
+0000135367 00000 n 
+0000135481 00000 n 
+0000135916 00000 n 
+0000135686 00000 n 
+0000135800 00000 n 
+0000210701 00000 n 
+0000136600 00000 n 
+0000136862 00000 n 
+0000136749 00000 n 
+0000140530 00000 n 
+0000137018 00000 n 
+0000137130 00000 n 
+0000137240 00000 n 
+0000186762 00000 n 
+0000137546 00000 n 
+0000137320 00000 n 
+0000137433 00000 n 
+0000137884 00000 n 
+0000137748 00000 n 
+0000187162 00000 n 
+0000138041 00000 n 
+0000138151 00000 n 
+0000138261 00000 n 
+0000244364 00000 n 
+0000138378 00000 n 
+0000138495 00000 n 
+0000387405 00000 n 
+0000138612 00000 n 
+0000138729 00000 n 
+0000138839 00000 n 
+0000138949 00000 n 
+0000139059 00000 n 
+0000139176 00000 n 
+0000139293 00000 n 
+0000387779 00000 n 
+0000139410 00000 n 
+0000139527 00000 n 
+0000139637 00000 n 
+0000139747 00000 n 
+0000139865 00000 n 
+0000140201 00000 n 
+0000139975 00000 n 
+0000140088 00000 n 
+0000140403 00000 n 
+0000210552 00000 n 
+0000140827 00000 n 
+0000209702 00000 n 
+0000140939 00000 n 
+0000187685 00000 n 
+0000141052 00000 n 
+0000187325 00000 n 
+0000605136 00000 n 
+0000605822 00000 n 
+0000187500 00000 n 
+0000604533 00000 n 
+0000604965 00000 n 
+0000187562 00000 n 
+0000209459 00000 n 
+0000209046 00000 n 
+0000187928 00000 n 
+0000209345 00000 n 
+0000604822 00000 n 
+0000244192 00000 n 
+0000210121 00000 n 
+0000209895 00000 n 
+0000210008 00000 n 
+0000210323 00000 n 
+0000211245 00000 n 
+0000210840 00000 n 
+0000211088 00000 n 
+0000210952 00000 n 
+0000388255 00000 n 
+0000392396 00000 n 
+0000211357 00000 n 
+0000211831 00000 n 
+0000211469 00000 n 
+0000211582 00000 n 
+0000211695 00000 n 
+0000388456 00000 n 
+0000213021 00000 n 
+0000212117 00000 n 
+0000212230 00000 n 
+0000212343 00000 n 
+0000212456 00000 n 
+0000212569 00000 n 
+0000212682 00000 n 
+0000212795 00000 n 
+0000212908 00000 n 
+0000213499 00000 n 
+0000213609 00000 n 
+0000213913 00000 n 
+0000213800 00000 n 
+0000214182 00000 n 
+0000214069 00000 n 
+0000392291 00000 n 
+0000389949 00000 n 
+0000214338 00000 n 
+0000389750 00000 n 
+0000214452 00000 n 
+0000389470 00000 n 
+0000214565 00000 n 
+0000389007 00000 n 
+0000389121 00000 n 
+0000389178 00000 n 
+0000605651 00000 n 
+0000388640 00000 n 
+0000388823 00000 n 
+0000389347 00000 n 
+0000389409 00000 n 
+0000445410 00000 n 
+0000390745 00000 n 
+0000390038 00000 n 
+0000390491 00000 n 
+0000390152 00000 n 
+0000390265 00000 n 
+0000390378 00000 n 
+0000391883 00000 n 
+0000390834 00000 n 
+0000391536 00000 n 
+0000390948 00000 n 
+0000391061 00000 n 
+0000445558 00000 n 
+0000391197 00000 n 
+0000391310 00000 n 
+0000391423 00000 n 
+0000392202 00000 n 
+0000391972 00000 n 
+0000392086 00000 n 
+0000448206 00000 n 
+0000392799 00000 n 
+0000392911 00000 n 
+0000393977 00000 n 
+0000393410 00000 n 
+0000393021 00000 n 
+0000393248 00000 n 
+0000393135 00000 n 
+0000393888 00000 n 
+0000393499 00000 n 
+0000393726 00000 n 
+0000393613 00000 n 
+0000394066 00000 n 
+0000394402 00000 n 
+0000394176 00000 n 
+0000394289 00000 n 
+0000394604 00000 n 
+0000396886 00000 n 
+0000394985 00000 n 
+0000395699 00000 n 
+0000395134 00000 n 
+0000395247 00000 n 
+0000395360 00000 n 
+0000395473 00000 n 
+0000395586 00000 n 
+0000396265 00000 n 
+0000396039 00000 n 
+0000396152 00000 n 
+0000396467 00000 n 
+0000448086 00000 n 
+0000397027 00000 n 
+0000447097 00000 n 
+0000446853 00000 n 
+0000397139 00000 n 
+0000446147 00000 n 
+0000445755 00000 n 
+0000445951 00000 n 
+0000446260 00000 n 
+0000446316 00000 n 
+0000446373 00000 n 
+0000446430 00000 n 
+0000446544 00000 n 
+0000446606 00000 n 
+0000446729 00000 n 
+0000446791 00000 n 
+0000462391 00000 n 
+0000448780 00000 n 
+0000448375 00000 n 
+0000448623 00000 n 
+0000448487 00000 n 
+0000462836 00000 n 
+0000449763 00000 n 
+0000448905 00000 n 
+0000449469 00000 n 
+0000449017 00000 n 
+0000449130 00000 n 
+0000449243 00000 n 
+0000449356 00000 n 
+0000450277 00000 n 
+0000449872 00000 n 
+0000450120 00000 n 
+0000449984 00000 n 
+0000463875 00000 n 
+0000450544 00000 n 
+0000462563 00000 n 
+0000464281 00000 n 
+0000451150 00000 n 
+0000464055 00000 n 
+0000463045 00000 n 
+0000463252 00000 n 
+0000463460 00000 n 
+0000463667 00000 n 
+0000464224 00000 n 
+0000606814 00000 n 
 0000000000 00000 f 
-0000603783 00000 n 
-0000464207 00000 n 
-0000464583 00000 n 
-0000464608 00000 n 
-0000464911 00000 n 
-0000465022 00000 n 
-0000465342 00000 n 
-0000465693 00000 n 
-0000466257 00000 n 
-0000466724 00000 n 
-0000467197 00000 n 
-0000467536 00000 n 
-0000467557 00000 n 
-0000468028 00000 n 
-0000468599 00000 n 
-0000476095 00000 n 
-0000476323 00000 n 
-0000478239 00000 n 
-0000478449 00000 n 
-0000485795 00000 n 
-0000486015 00000 n 
-0000495598 00000 n 
-0000495875 00000 n 
-0000508828 00000 n 
-0000509212 00000 n 
-0000519960 00000 n 
-0000520321 00000 n 
-0000531245 00000 n 
-0000531603 00000 n 
-0000540616 00000 n 
-0000541049 00000 n 
-0000546793 00000 n 
-0000547086 00000 n 
-0000561320 00000 n 
-0000561697 00000 n 
-0000571936 00000 n 
-0000572225 00000 n 
-0000591020 00000 n 
-0000591525 00000 n 
-0000603450 00000 n 
-0000606613 00000 n 
-0000606682 00000 n 
-0000607992 00000 n 
-0000608161 00000 n 
-0000608339 00000 n 
-0000608562 00000 n 
-0000608786 00000 n 
-0000608948 00000 n 
-0000609134 00000 n 
-0000609342 00000 n 
-0000609527 00000 n 
-0000609642 00000 n 
-0000609731 00000 n 
-0000609818 00000 n 
-0000609856 00000 n 
-0000610059 00000 n 
+0000604061 00000 n 
+0000464485 00000 n 
+0000464861 00000 n 
+0000464886 00000 n 
+0000465189 00000 n 
+0000465300 00000 n 
+0000465620 00000 n 
+0000465971 00000 n 
+0000466535 00000 n 
+0000467002 00000 n 
+0000467475 00000 n 
+0000467814 00000 n 
+0000467835 00000 n 
+0000468306 00000 n 
+0000468877 00000 n 
+0000476373 00000 n 
+0000476601 00000 n 
+0000478517 00000 n 
+0000478727 00000 n 
+0000486073 00000 n 
+0000486293 00000 n 
+0000495876 00000 n 
+0000496153 00000 n 
+0000509106 00000 n 
+0000509490 00000 n 
+0000520238 00000 n 
+0000520599 00000 n 
+0000531523 00000 n 
+0000531881 00000 n 
+0000540894 00000 n 
+0000541327 00000 n 
+0000547071 00000 n 
+0000547364 00000 n 
+0000561598 00000 n 
+0000561975 00000 n 
+0000572214 00000 n 
+0000572503 00000 n 
+0000591298 00000 n 
+0000591803 00000 n 
+0000603728 00000 n 
+0000606891 00000 n 
+0000606960 00000 n 
+0000608261 00000 n 
+0000608430 00000 n 
+0000608608 00000 n 
+0000608831 00000 n 
+0000609055 00000 n 
+0000609217 00000 n 
+0000609403 00000 n 
+0000609619 00000 n 
+0000609864 00000 n 
+0000609979 00000 n 
+0000610068 00000 n 
+0000610155 00000 n 
+0000610193 00000 n 
+0000610396 00000 n 
 trailer
-<< /Size 606
-/Root 604 0 R
-/Info 605 0 R
-/ID [<741085D615FB82FCE1C01458A609F8B8> <741085D615FB82FCE1C01458A609F8B8>] >>
+<< /Size 608
+/Root 606 0 R
+/Info 607 0 R
+/ID [<1BDA902AA64AD48937877A8F77890179> <1BDA902AA64AD48937877A8F77890179>] >>
 startxref
-610996
+611333
 %%EOF

--- a/accessibilityMeta.sty
+++ b/accessibilityMeta.sty
@@ -2096,6 +2096,19 @@ The command name specified by \string\newacronym already exists.}}}
   }{}%
 }{}
 
+
+% The count1to package confuses hyperref (see hyperref README), so fix \theH<...>:
+\@ifpackageloaded{hyperref}{%
+  \AtBeginDocument{%
+    \ifthenelse{\isundefined{\theHchapter}}{\newcommand{\theHchapter}{0}}{}%
+    \renewcommand*{\theHsection}{\theHchapter.\arabic{section}}%
+    \renewcommand*{\theHsubsection}{\theHsection.\arabic{subsection}}%
+    \renewcommand*{\theHsubsubsection}{\theHsubsection.\arabic{subsubsection}}%
+    \renewcommand*{\theHparagraph}{\theHsubsubsection.\arabic{paragraph}}%
+    \renewcommand*{\theHsubparagraph}{\theHparagraph.\arabic{subparagraph}}%
+  }%
+}%
+
 \endinput
 %%
 %% End of file `accessibility.sty'.


### PR DESCRIPTION
As stated in the hyperref README[1], the count1to package confuses the
internal numbering of the hyperref package. In the demo PDF, this can be seen
in the TOC: Clicking on the "4.1 Including code listings" TOC entry leads to
"3.1 A “meta” LaTeX style file". This problem also gives two warnings about
duplicate names.

Fix this by using an adaptation of the suggested fix from the hyperref README.

[1] https://www.ctan.org/tex-archive/macros/latex/contrib/hyperref?lang=en