### PR TITLE
.gitignore *.fls files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.blg
 *.dvi
 *.fdb_latexmk
+*.fls
 *.glg
 *.glo
 *.gls


### PR DESCRIPTION
`latex -recorder` (e.g. by using latexmk) creates `*.fls` files. Let git ignore them.